### PR TITLE
Modernize stack with HTML5 and MariaDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@
 
     
     Version htn2src.2.0-RC5
-    
+
     Systemanforderungen:
-      PHP 4: mindestens PHP 4.2.0 (nicht lauffähig unter PHP 5)
-      MySQL 4.0.x
-      Apache-Webserver empfohlen
+      PHP 8 oder höher
+      MariaDB 10.x oder kompatible MySQL-Implementierung
+      Moderner Webserver (z.B. Apache oder Nginx)
       
       Unter Linux:
         chmod -R 0777 data

--- a/global.js
+++ b/global.js
@@ -1,5 +1,5 @@
-window.onload = startsynchr;
-window.onerror = catcherr;
+window.addEventListener('load', startsynchr);
+window.addEventListener('error', catcherr);
 
 if (document.all) {
     document.onmouseover = linkover;
@@ -33,7 +33,7 @@ function synchrclock() {
     getLay("server-time").innerHTML = fmtint(c.getHours()) + ":" + fmtint(c.getMinutes()) + ":" + fmtint(c.getSeconds()) + " Uhr";
 }
 function startsynchr() {
-    setInterval("synchrclock()", 1000);
+    setInterval(synchrclock, 1000);
 }
 
 
@@ -62,7 +62,7 @@ function param(name) {
 }
 
 
-var newwin;
+let newwin;
 function show_abook(type) {
 
     l = parseInt((screen.availWidth - 500) / 2);

--- a/gres.php
+++ b/gres.php
@@ -36,13 +36,73 @@ include 'config.php';
 $STYLESHEET = $standard_stylesheet;
 
 if ($db_use_this_values) {
-    $dbcon = @mysql_connect($db_host, $db_username, $db_password);
+    $dbcon = @mysqli_connect($db_host, $db_username, $db_password);
 } else {
-    $dbcon = @mysql_connect();
+    $dbcon = @mysqli_connect();
 }
 
 if (!$dbcon) {
     die('Datenbankzugriff gescheitert! Bitte nochmal probieren.');
+}
+mysqli_set_charset($dbcon, 'utf8');
+
+function mysql_escape_string($str)
+{
+    global $dbcon;
+    return mysqli_real_escape_string($dbcon, $str);
+}
+
+function mysql_query($q)
+{
+    global $dbcon;
+    return mysqli_query($dbcon, $q);
+}
+
+function mysql_error()
+{
+    global $dbcon;
+    return mysqli_error($dbcon);
+}
+
+function mysql_num_rows($r)
+{
+    return mysqli_num_rows($r);
+}
+
+function mysql_fetch_assoc($r)
+{
+    return mysqli_fetch_assoc($r);
+}
+
+function mysql_result($r, $row, $field = 0)
+{
+    mysqli_data_seek($r, $row);
+    $d = mysqli_fetch_array($r);
+    return $d[$field];
+}
+
+function mysql_insert_id()
+{
+    global $dbcon;
+    return mysqli_insert_id($dbcon);
+}
+
+function mysql_data_seek($r, $offset)
+{
+    return mysqli_data_seek($r, $offset);
+}
+
+function mysql_select_db($dbname)
+{
+    global $dbcon;
+    return mysqli_select_db($dbcon, $dbname);
+}
+
+function mysql_db_query($db, $sql)
+{
+    global $dbcon;
+    mysqli_select_db($dbcon, $db);
+    return mysqli_query($dbcon, $sql);
 }
 
 /* ohne magic quotes brauch man das ja nicht mehr
@@ -92,9 +152,10 @@ function dbname($srvid = -1)
 
 function db_query($q)
 {
-    $r = mysql_query($q);
-    if (mysql_error() != '') {
-        die('<tt>'.$q.'</tt><br />caused an error:<br />'.mysql_error());
+    global $dbcon;
+    $r = mysqli_query($dbcon, $q);
+    if (mysqli_error($dbcon) != '') {
+        die('<tt>' . $q . '</tt><br />caused an error:<br />' . mysqli_error($dbcon));
     }
 
     return $r;

--- a/layout.php
+++ b/layout.php
@@ -37,18 +37,17 @@ function basicheader($title)
     }
 
     $ts = time() + 1;
-    echo '<?xml version="1.0" encoding="ISO-8859-1"?>'."\n";
-    echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html>
-<head>
-<title>'.$title.'</title>
-<link rel="stylesheet" type="text/css" href="'.$STYLESHEET_BASEDIR.$stylesheet.'/style.css" />
-<script type="text/javascript">var stm=new Date(); stm.setTime('.$ts.'000); var sltm=new Date();</script>
-<script type="text/javascript" src="global.js"></script>
-<link rel="SHORTCUT ICON" href="favicon.ico" />
-'.$javascript.'
-</head>
-';
+    echo '<!DOCTYPE html>'."\n";
+    echo '<html lang="de">' . "\n";
+    echo '<head>' . "\n";
+    echo '<meta charset="utf-8">' . "\n";
+    echo '<title>' . $title . '</title>' . "\n";
+    echo '<link rel="stylesheet" href="' . $STYLESHEET_BASEDIR . $stylesheet . '/style.css">' . "\n";
+    echo '<script>var stm=new Date(); stm.setTime(' . $ts . '000); var sltm=new Date();</script>' . "\n";
+    echo '<script src="global.js" defer></script>' . "\n";
+    echo '<link rel="icon" href="favicon.ico">' . "\n";
+    echo $javascript;
+    echo '</head>' . "\n";
 }
 
 function basicfooter()


### PR DESCRIPTION
## Summary
- Output HTML5 markup with UTF-8 charset
- Replace deprecated mysql_* functions with mysqli wrappers for MariaDB compatibility
- Modernize JavaScript initialization and interval usage
- Update documentation with new PHP/MariaDB requirements

## Testing
- `php -l gres.php`
- `php -l layout.php`
- `node --check global.js`


------
https://chatgpt.com/codex/tasks/task_b_689c615353ec83258825930c29a3ec51