### PR TITLE
Handle stale ranking calculation files and randomx helper

### DIFF
--- a/calc_points.php
+++ b/calc_points.php
@@ -13,6 +13,11 @@ file_put('data/calc-running.dat', 'yes');
 file_put('data/calc-time.dat', time() + UPDATE_INTERVAL);
 file_put('data/calc-stat.dat', 'gerade angefangen');
 
+register_shutdown_function(function () {
+    @unlink('data/calc-running.dat');
+    @unlink('data/calc-stat.dat');
+});
+
 file_put('data/upgr_SALT.dat', randomx(6));
 chmod('data/upgr_SALT.dat', 0777);
 

--- a/gres.php
+++ b/gres.php
@@ -389,6 +389,13 @@ function RandomX($chars = 6, $cs = true)
     return $s;
 }
 
+if (!function_exists('randomx')) {
+    function randomx($chars = 6, $cs = true)
+    {
+        return RandomX($chars, $cs);
+    }
+}
+
 function randomchar()
 {
     $s = randomx(16);

--- a/login.php
+++ b/login.php
@@ -25,8 +25,18 @@ if ($action == '') {
 }
 
 if ($action == 'login') {
+    $calcRunFile = 'data/calc-running.dat';
+    $calcRunning = @file_get($calcRunFile);
+    if ($calcRunning == 'yes') {
+        $mtime = @filemtime($calcRunFile);
+        if ($mtime !== false && $mtime + 900 < time()) {
+            @unlink($calcRunFile);
+            @unlink('data/calc-stat.dat');
+            $calcRunning = '';
+        }
+    }
 
-    if ((int)@file_get('data/calc-time.dat') <= time() || @file_get('data/calc-running.dat') == 'yes') {
+    if ((int)@file_get('data/calc-time.dat') <= time() || $calcRunning == 'yes') {
         $pwd = urlencode($_REQUEST['pwd']);
         $nick = urlencode($_REQUEST['nick']);
         $stat = @file_get('data/calc-stat.dat');
@@ -37,7 +47,7 @@ if ($action == 'login') {
 <b>Der Server ist im Moment mit der Kalkulation der Punktest&auml;nde besch&auml;ftigt!</b>
 <br /><br />Aktueller Status: <tt>'.$stat.'</tt>
 </body></html>';
-        if (@file_get('data/calc-running.dat') == '') {
+        if ($calcRunning == '') {
             include('calc_points.php');
         }
         exit;


### PR DESCRIPTION
## Summary
- Clean up `calc-running.dat`/`calc-stat.dat` via shutdown handler so stalled point calculations don't block logins.
- Detect and remove stale `calc-running.dat` before login, resuming normal login flow.
- Provide `randomx()` helper alias to avoid missing function errors.

## Testing
- `php -l calc_points.php`
- `php -l gres.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_b_689c7932c54c8325b5f9f39d86d819a4