### PR TITLE
Handle stale ranking calculation files and randomx helper

### DIFF
--- a/calc_points.php
+++ b/calc_points.php
@@ -13,6 +13,11 @@ file_put('data/calc-running.dat', 'yes');
 file_put('data/calc-time.dat', time() + UPDATE_INTERVAL);
 file_put('data/calc-stat.dat', 'gerade angefangen');
 
+register_shutdown_function(function () {
+    @unlink('data/calc-running.dat');
+    @unlink('data/calc-stat.dat');
+});
+
 file_put('data/upgr_SALT.dat', randomx(6));
 chmod('data/upgr_SALT.dat', 0777);
 

--- a/gres.php
+++ b/gres.php
@@ -34,6 +34,7 @@ Du kannst auch so lange dem <a href="http://forum.hackthenet.org/">Forum</a> ode
 
 include 'config.php';
 $STYLESHEET = $standard_stylesheet;
+mysqli_report(MYSQLI_REPORT_OFF);
 
 if ($db_use_this_values) {
     $dbcon = @mysqli_connect($db_host, $db_username, $db_password);
@@ -387,6 +388,13 @@ function RandomX($chars = 6, $cs = true)
     $s = substr($s, mt_rand(0, $chars), $chars);
 
     return $s;
+}
+
+if (!function_exists('randomx')) {
+    function randomx($chars = 6, $cs = true)
+    {
+        return RandomX($chars, $cs);
+    }
 }
 
 function randomchar()

--- a/login.php
+++ b/login.php
@@ -25,8 +25,18 @@ if ($action == '') {
 }
 
 if ($action == 'login') {
+    $calcRunFile = 'data/calc-running.dat';
+    $calcRunning = @file_get($calcRunFile);
+    if ($calcRunning == 'yes') {
+        $mtime = @filemtime($calcRunFile);
+        if ($mtime !== false && $mtime + 900 < time()) {
+            @unlink($calcRunFile);
+            @unlink('data/calc-stat.dat');
+            $calcRunning = '';
+        }
+    }
 
-    if ((int)@file_get('data/calc-time.dat') <= time() || @file_get('data/calc-running.dat') == 'yes') {
+    if ((int)@file_get('data/calc-time.dat') <= time() || $calcRunning == 'yes') {
         $pwd = urlencode($_REQUEST['pwd']);
         $nick = urlencode($_REQUEST['nick']);
         $stat = @file_get('data/calc-stat.dat');
@@ -37,7 +47,7 @@ if ($action == 'login') {
 <b>Der Server ist im Moment mit der Kalkulation der Punktest&auml;nde besch&auml;ftigt!</b>
 <br /><br />Aktueller Status: <tt>'.$stat.'</tt>
 </body></html>';
-        if (@file_get('data/calc-running.dat') == '') {
+        if ($calcRunning == '') {
             include('calc_points.php');
         }
         exit;


### PR DESCRIPTION
## Summary
- Clean up `calc-running.dat`/`calc-stat.dat` via shutdown handler so stalled point calculations don't block logins.
- Detect and remove stale `calc-running.dat` before login, resuming normal login flow.
- Provide `randomx()` helper alias to avoid missing function errors.
- Disable mysqli strict error reporting to prevent uncaught connection exceptions from causing HTTP 500 during login.

## Testing
- `php -l calc_points.php`
- `php -l gres.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_b_689c7932c54c8325b5f9f39d86d819a4