### PR TITLE
Fix login cookie check to prevent TypeError

### DIFF
--- a/login.php
+++ b/login.php
@@ -78,7 +78,11 @@ if ($action == 'login') {
 
     $cookie = false;
 
-    if (substr_count(($_COOKIE['htnLoginData4']), '|') == 2 && $_POST['save'] == 'yes') {
+    if (
+        isset($_COOKIE['htnLoginData4']) &&
+        substr_count($_COOKIE['htnLoginData4'], '|') == 2 &&
+        $_POST['save'] == 'yes'
+    ) {
         list($serverdummy, $usrnamedummy, $pwd) = explode('|', $_COOKIE['htnLoginData4']);
         $cookie = true;
     }


### PR DESCRIPTION
## Summary
- prevent PHP 8 TypeError by checking for `htnLoginData4` cookie before counting delimiters

## Testing
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_b_689c7ec8ee708325a76c02df710ea0f8