### PR TITLE
Ensure login session directory exists

### DIFF
--- a/gres.php
+++ b/gres.php
@@ -240,7 +240,11 @@ function gFormatText(&$s)
 function write_session_data()
 {
     global $usrid, $pcid, $sid, $server;
-    file_put('data/login/'.$sid.'.txt', $server."\x0b".$usrid."\x0b".$pcid);
+    $dir = 'data/login';
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0777, true);
+    }
+    file_put($dir.'/'.$sid.'.txt', $server."\x0b".$usrid."\x0b".$pcid);
 }
 
 function is_noranKINGuser($ix)


### PR DESCRIPTION
## Summary
- prevent invalid session errors by creating the `data/login` folder automatically before writing session data

## Testing
- `php -l gres.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_b_689c8211ad3c8325b6db27566dcaf5d3