### PR TITLE
Fix PC listing errors and clean up warnings

### DIFF
--- a/game.php
+++ b/game.php
@@ -4,18 +4,19 @@ define('IN_HTN', 1);
 $FILE_REQUIRES_PC = true;
 include('ingame.php');
 
-$action = $_REQUEST['page'];
-if ($action == '') {
-    $action = $_REQUEST['mode'];
+// Determine requested action while avoiding undefined index warnings
+$action = $_REQUEST['page'] ?? '';
+if ($action === '') {
+    $action = $_REQUEST['mode'] ?? '';
 }
-if ($action == '') {
-    $action = $_REQUEST['action'];
+if ($action === '') {
+    $action = $_REQUEST['action'] ?? '';
 }
-if ($action == '') {
-    $action = $_REQUEST['a'];
+if ($action === '') {
+    $action = $_REQUEST['a'] ?? '';
 }
-if ($action == '') {
-    $action = $_REQUEST['m'];
+if ($action === '') {
+    $action = $_REQUEST['m'] ?? '';
 }
 
 $bucks = number_format($pc['credits'], 0, ',', '.');
@@ -948,6 +949,9 @@ switch ($action) {
             {
                 $pc = $x;
                 $avail = isavailh('scan', $x);
+                // initialise variables before passing by reference
+                $next = 0;
+                $last = 0;
                 if (!isattackallowed($next, $last) && $avail) {
                     $attack = 'nein, erst wieder '.nicetime3($next);
                 } elseif ($avail) {
@@ -1032,7 +1036,7 @@ switch ($action) {
                 if (strlen($n) > 1 && strlen($n) <= 30) {
                     $xpc = GetPC($a[$i]);
                     $xpc['name'] = $n;
-                    savepc($a[$i], $xpc);
+                    SavePC($a[$i], $xpc);
                 }
             }
         }

--- a/gres.php
+++ b/gres.php
@@ -119,6 +119,9 @@ foreach ($_GET as $bez => $val) $_GET[$bez] = rem_esc_chars($val);
 foreach ($_REQUEST as $bez => $val) $_REQUEST[$bez] = rem_esc_chars($val);
 reset($_POST); reset($_REQUEST); reset($_GET); */
 
+// initialise notification placeholder
+$notif = '';
+
 if (file_exists('data/mysql-backup-prepare.txt') == true) {
     $notif = '<div class="work">
 <h3>Server-Arbeiten</h3>
@@ -659,6 +662,7 @@ function getPCPoints($pc, $mode = 'byid')
 
 function GetIP()
 { //------------------------- Get IP -------------------------------
+    $proxy = null;
     if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
         if (isset($_SERVER['HTTP_CLIENT_IP'])) {
             $proxy = $_SERVER['HTTP_CLIENT_IP'];

--- a/layout.php
+++ b/layout.php
@@ -60,6 +60,7 @@ function basicfooter()
 function createlayout_top($title = 'HackTheNet', $nomenu = false, $pads = true)
 {
     global $usr, $javascript, $STYLESHEET, $bodytag, $localhost, $FILE_REQUIRES_PC, $pc, $pcid;
+    $ads = '';
     if ($usr['sid'] != '') {
         $sid = '&amp;sid='.$usr['sid'];
     }


### PR DESCRIPTION
## Summary
- Prevent undefined index warnings when determining requested action
- Initialize variables and correct function calls for PC listing
- Define missing variables in common helpers to avoid warnings

## Testing
- `php -l game.php`
- `php -l gres.php`
- `php -l layout.php`


------
https://chatgpt.com/codex/tasks/task_b_689c85e291d0832593ae7d26862e0d7e