### PR TITLE
Guard against missing request data and uninitialized variables

### DIFF
--- a/cluster.php
+++ b/cluster.php
@@ -5,19 +5,19 @@ $FILE_REQUIRES_PC = false;
 include('ingame.php');
 
 
-$action = $_REQUEST['page'];
+$action = $_REQUEST['page'] ?? '';
 # Die folgenden Variablen sollten nicht mehr verwendet werden
 if ($action == '') {
-    $action = $_REQUEST['mode'];
+    $action = $_REQUEST['mode'] ?? '';
 }
 if ($action == '') {
-    $action = $_REQUEST['action'];
+    $action = $_REQUEST['action'] ?? '';
 }
 if ($action == '') {
-    $action = $_REQUEST['a'];
+    $action = $_REQUEST['a'] ?? '';
 }
 if ($action == '') {
-    $action = $_REQUEST['m'];
+    $action = $_REQUEST['m'] ?? '';
 }
 
 # Konstanten für Cluster-Verträge:
@@ -105,6 +105,7 @@ Dort findest du einen "Mitgliedsantrag stellen"-Link.</p></div>
         }
 
         $a = explode("\n", $cluster['events']);
+        $mod = false;
         if (count($a) > 21) {
             $cluster['events'] = joinex(array_slice($a, 0, 20), "\n");
             $mod = true;

--- a/game.php
+++ b/game.php
@@ -40,7 +40,7 @@ switch ($action) {
 
         $info = "\n";
 
-        if ($_GET['nlo'] == 1) {
+        if (($_GET['nlo'] ?? 0) == 1) {
             $info .= infobox(
                 'ACHTUNG!!',
                 'error',
@@ -99,6 +99,7 @@ switch ($action) {
         }
 
 # Anzahl neuer Mails festellen + updaten
+        $newtotal = 0;
         if ($usr['newmail'] > 0) {
             $newmail = @mysql_num_rows(
                 db_query(
@@ -248,6 +249,8 @@ switch ($action) {
             $rhinfo .= '</td></tr>';
         }
 
+        $op = '';
+        $transfer = '';
         if ($pc['mk'] >= 1) {
             $op = ' | <a href="battle.php?m=opc&amp;sid='.$sid.'">Operation Center</a>';
         }
@@ -868,7 +871,7 @@ switch ($action) {
         echo '<th class="hijack">Hijack?</th>'.LF.'</tr>'."\n";
 
 
-        $st = $_POST['sorttype'];
+         $st = $_POST['sorttype'] ?? '';
         switch ($st) {
             case 'name ASC':
                 break;
@@ -896,9 +899,10 @@ switch ($action) {
                 ).$ord.';'
             );
         }
-        while ($x = mysql_fetch_assoc($sql)) {
-            #$list.=$x['id'].',';
-            $number++;
+         $number = 0;
+         while ($x = mysql_fetch_assoc($sql)) {
+             #$list.=$x['id'].',';
+             $number++;
             $country = GetCountry('id', $x['country']);
             $x['points'] = (int)$x['points'];
             if ($x['points'] < 1024 && $ext) {

--- a/layout.php
+++ b/layout.php
@@ -93,6 +93,7 @@ function createlayout_top($title = 'HackTheNet', $nomenu = false, $pads = true)
                 '&Uuml;bersicht &uuml;ber alles Wichtige auf einen Blick.'
             );
 
+            $hw = '';
             if ($usr['newmail'] > 0) {
                 $hw = ($usr['newmail'] == 1 ? '' : 's');
                 $hw = 'Du hast '.$usr['newmail'].' neue Message'.$hw;


### PR DESCRIPTION
## Summary
- Avoid undefined index warnings by guarding optional request parameters in cluster and game scripts
- Initialize variables for menu messages and PC listing to prevent undefined variable notices

## Testing
- `php -l cluster.php`
- `php -l game.php`
- `php -l layout.php`


------
https://chatgpt.com/codex/tasks/task_b_689c87b8af848325981fcaa86eb5335d