### PR TITLE
Fix undefined variable warnings in gameplay scripts

### DIFF
--- a/cluster.php
+++ b/cluster.php
@@ -328,10 +328,9 @@ Dort findest du einen "Mitgliedsantrag stellen"-Link.</p></div>
 
             createlayout_top('HackTheNet - Cluster - Vertr&auml;ge');
             echo '<div class="content" id="cluster">
-<h2>Cluster</h2>
-'.$notif.'<div id="cluster-create-convent">
+<h2>Cluster</h2>'
+                .$notif.'<div id="cluster-create-convent">
 <h3>Vertrag erstellen</h3>
-'.$xxx.'
 <form action="cluster.php?page=saveconvents&amp;sid='.$sid.'" method="post">
 <table>
 <tr>

--- a/game.php
+++ b/game.php
@@ -239,6 +239,7 @@ switch ($action) {
             echo '<br />'."\n";
         }
 
+        $rhinfo = '';
         if ($pc['mk'] > 0 && $pc['rh'] > 0) {
             $rhinfo = '<tr><th>Remote Hijack</th><td>';
             if ($pc['lrh'] + REMOTE_HIJACK_DELAY <= time()) {
@@ -670,6 +671,7 @@ switch ($action) {
             echo '<table>'."\n";
             echo '<tr>'.LF.'<th>Item</th>'.LF.'<th>Dauer</th>'.LF.'<th>Fertigstellung</th>'.LF.'<th>Kosten</th>'.LF.'<th>Upgrade</th>'.LF.'</tr>'."\n";
             reset($items);
+            $cnt = 0;
             foreach ($items as $dummy => $item) {
                 if (buildinfo($item)) {
                     $cnt++;

--- a/ingame.php
+++ b/ingame.php
@@ -645,11 +645,13 @@ function getmaxmails($box)
 
 function is_pc_attackable($pcdat) //---------------- IS PC ATTACKABLE ? ----------------
 {
+    $owner = getuser($pcdat['owner']);
     $xdefence = $pcdat['fw'] + $pcdat['av'] + $pcdat['ids'] / 2;
     $rscan = (int)(isavailh('scan', $pcdat));
     # ^^ 0 <= $xdefence <= 25 ^^
     #echo '<br />xdefence='.$xdefence.' min='.MIN_ATTACK_XDEFENCE.' scan='.(int)(isavailh('scan',$pcdat));
-    if (count(explode(',', $owner['pcs'])) < 2 && (
+    $ownerPcCount = ($owner !== false ? count(explode(',', $owner['pcs'])) : 0);
+    if ($ownerPcCount < 2 && (
         ($xdefence <= MIN_ATTACK_XDEFENCE && isavailh('scan', $pcdat) == false)
         )
     ) {

--- a/layout.php
+++ b/layout.php
@@ -170,9 +170,10 @@ function createlayout_top($title = 'HackTheNet', $nomenu = false, $pads = true)
 function createlayout_bottom()
 {
     global $starttime;
+    $time = '';
     if ($starttime > 0) {
         $time = (float)calc_time($starttime, 0, 10);
-        if ($t < 1) {
+        if ($time < 1) {
             $time = number_format($time * 1000, 1, '.', ',').' ms';
         } else {
             $time = number_format($time, 2, ',', '.').' s';


### PR DESCRIPTION
## Summary
- Initialize timer in layout footer and use computed value safely
- Prevent warnings in PC upgrade table by initializing counter
- Load PC owner in attack check to avoid undefined variable
- Remove leftover placeholder from cluster convent creation view
- Initialize remote hijack info before output to avoid undefined variable

## Testing
- `php -l layout.php game.php ingame.php cluster.php`


------
https://chatgpt.com/codex/tasks/task_b_689c9fa89e68832587a81e6ebcaff6f2