### PR TITLE
Run score recalculation asynchronously during login

### DIFF
--- a/run_calc_points.php
+++ b/run_calc_points.php
@@ -1,0 +1,7 @@
+<?php
+// Wrapper script to run point calculation from CLI.
+// Defines IN_HTN constant and includes calc_points.php
+// to allow execution without direct web access.
+
+define('IN_HTN', 1);
+require __DIR__ . '/calc_points.php';


### PR DESCRIPTION
## Summary
- trigger score calculation in background when it's due instead of blocking login
- add CLI wrapper script for running the calculation
- prevent undefined index warnings in login by defaulting missing request parameters

## Testing
- `php -l login.php run_calc_points.php`


------
https://chatgpt.com/codex/tasks/task_b_689ca48bb36c832584b5e31082bd9af9