### PR TITLE
Fix PHP8 incompatibilities in registration flow

### DIFF
--- a/game.php
+++ b/game.php
@@ -242,10 +242,11 @@ switch ($action) {
         $rhinfo = '';
         if ($pc['mk'] > 0 && $pc['rh'] > 0) {
             $rhinfo = '<tr><th>Remote Hijack</th><td>';
-            if ($pc['lrh'] + REMOTE_HIJACK_DELAY <= time()) {
+            $lastRemote = (int)$pc['lrh'] + REMOTE_HIJACK_DELAY;
+            if ($lastRemote <= time()) {
                 $rhinfo .= '<span style="color:green;">sofort verf&uuml;gbar</span>';
             } else {
-                $rhinfo .= nicetime($pc['lrh'] + REMOTE_HIJACK_DELAY);
+                $rhinfo .= nicetime($lastRemote);
             }
             $rhinfo .= '</td></tr>';
         }

--- a/pub.php
+++ b/pub.php
@@ -153,7 +153,7 @@ Nur wenn eine korrekte Email-Adresse angegeben wurde, kann der Account aktiviert
                     break;
                 }
             }
-            $x = eregi_replace('[-_:@.!=?$%&/0-9]', '', $nick);
+            $x = preg_replace('#[-_:@.!=?\$%&/0-9]#i', '', $nick);
             if (trim($x) == '') {
                 $b = false;
             }
@@ -178,8 +178,8 @@ Nur wenn eine korrekte Email-Adresse angegeben wurde, kann der Account aktiviert
                 $e = true;
                 $msg .= 'Der Nickname muss zwischen 3 und 20 Zeichen lang sein.<br />';
             }
-            $x = eregi_replace('[-_:@.!=?$%&/0-9]', '', $nick);
-            if (eregi('('.$badwords.')', $x) != false) {
+            $x = preg_replace('#[-_:@.!=?\$%&/0-9]#i', '', $nick);
+            if (preg_match('#(' . $badwords . ')#i', $x) != false) {
                 $e = true;
                 $msg .= 'Der Nickname darf bestimmte W&ouml;rter nicht enthalten.<br />';
             }


### PR DESCRIPTION
## Summary
- Cast last remote hijack timestamp to int before arithmetic
- Replace deprecated `eregi*` calls in registration with `preg_*`

## Testing
- `php -l game.php`
- `php -l pub.php`


------
https://chatgpt.com/codex/tasks/task_b_689ca9cb921083258d04e5e8ef2900cd