### PR TITLE
Fix PHP8 incompatibilities in registration flow

### DIFF
--- a/game.php
+++ b/game.php
@@ -242,10 +242,11 @@ switch ($action) {
         $rhinfo = '';
         if ($pc['mk'] > 0 && $pc['rh'] > 0) {
             $rhinfo = '<tr><th>Remote Hijack</th><td>';
-            if ($pc['lrh'] + REMOTE_HIJACK_DELAY <= time()) {
+            $lastRemote = (int)$pc['lrh'] + REMOTE_HIJACK_DELAY;
+            if ($lastRemote <= time()) {
                 $rhinfo .= '<span style="color:green;">sofort verf&uuml;gbar</span>';
             } else {
-                $rhinfo .= nicetime($pc['lrh'] + REMOTE_HIJACK_DELAY);
+                $rhinfo .= nicetime($lastRemote);
             }
             $rhinfo .= '</td></tr>';
         }

--- a/gres.php
+++ b/gres.php
@@ -323,6 +323,7 @@ function rem_esc_chars($s)
 function file_get($filename)
 { //----------- File Get -----------------
     global $STYLESHEET, $REMOTE_FILES_DIR, $DATADIR;
+    $fdata = '';
     $file = @fopen($filename, 'r');
     if ($file) {
         if ($fsize = @filesize($filename)) {
@@ -333,6 +334,8 @@ function file_get($filename)
             }
         }
         fclose($file);
+    } else {
+        return false;
     }
     if ($_SERVER['HTTP_HOST'] == 'localhost') {
         return str_replace("\r", '', $fdata);
@@ -884,10 +887,10 @@ function rem_e_callback($s)
 
 function check_email($email)
 { // ------------------ CHECK EMAIL ---------------
-    return (eregi(
-        '^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,4}$',
+    return preg_match(
+        '/^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-.]?[0-9a-zA-Z])*\\.[a-zA-Z]{2,4}$/i',
         $email
-    ) === false ? false : true);
+    ) === 1;
 }
 
 function GetTableInfo($table, $db = '')

--- a/pub.php
+++ b/pub.php
@@ -153,7 +153,7 @@ Nur wenn eine korrekte Email-Adresse angegeben wurde, kann der Account aktiviert
                     break;
                 }
             }
-            $x = eregi_replace('[-_:@.!=?$%&/0-9]', '', $nick);
+            $x = preg_replace('#[-_:@.!=?\$%&/0-9]#i', '', $nick);
             if (trim($x) == '') {
                 $b = false;
             }
@@ -178,8 +178,8 @@ Nur wenn eine korrekte Email-Adresse angegeben wurde, kann der Account aktiviert
                 $e = true;
                 $msg .= 'Der Nickname muss zwischen 3 und 20 Zeichen lang sein.<br />';
             }
-            $x = eregi_replace('[-_:@.!=?$%&/0-9]', '', $nick);
-            if (eregi('('.$badwords.')', $x) != false) {
+            $x = preg_replace('#[-_:@.!=?\$%&/0-9]#i', '', $nick);
+            if (preg_match('#(' . $badwords . ')#i', $x) != false) {
                 $e = true;
                 $msg .= 'Der Nickname darf bestimmte W&ouml;rter nicht enthalten.<br />';
             }
@@ -200,8 +200,14 @@ Nur wenn eine korrekte Email-Adresse angegeben wurde, kann der Account aktiviert
 
             $pwd = generateMnemonicPassword();
             $tmpfnx = randomx(REG_CODE_LEN);
-            $tmpfn = 'data/regtmp/'.$tmpfnx.'.txt';
-            file_put($tmpfn, $nick.'|'.$email.'|'.$pwd.'|'.$server);
+            $tmpdir = 'data/regtmp';
+            if (!is_dir($tmpdir) && !mkdir($tmpdir, 0777, true)) {
+                die('FUCK OFF!');
+            }
+            $tmpfn = $tmpdir.'/'.$tmpfnx.'.txt';
+            if (!file_put($tmpfn, $nick.'|'.$email.'|'.$pwd.'|'.$server)) {
+                die('FUCK OFF!');
+            }
 
             $selcode = str_replace('%path%', 'images/maps', file_get('data/pubtxt/selcountry_body.txt'));
             echo '<div class="content" id="register">
@@ -226,11 +232,19 @@ Nur wenn eine korrekte Email-Adresse angegeben wurde, kann der Account aktiviert
     case 'regsubmit2':  // ----------------------- RegSubmit 2 --------------------------
 
         $tmpfnx = $_POST['code'];
-        if (preg_match("/^[a-z0-9]+$/i", $tmpfnx) === false) {
+        if (preg_match('/^[a-z0-9]+$/i', $tmpfnx) !== 1) {
             die('FUCK OFF!');
         }
         $fn = 'data/regtmp/'.$tmpfnx.'.txt';
-        list($nick, $email, $pwd, $server) = explode('|', file_get($fn));
+        $regtmp = file_get($fn);
+        if ($regtmp === false) {
+            die('FUCK OFF!');
+        }
+        $parts = explode('|', $regtmp);
+        if (count($parts) < 4) {
+            die('FUCK OFF!');
+        }
+        list($nick, $email, $pwd, $server) = $parts;
         mysql_select_db(dbname($server));
 
         createlayout_top('HackTheNet - Account anlegen');


### PR DESCRIPTION
## Summary
- Cast last remote hijack timestamp to int before arithmetic
- Replace deprecated `eregi*` calls in registration with `preg_*`
- Use `preg_match` for email validation to remove `eregi` dependency
- Initialize file_get buffer and validate temp registration data to avoid undefined warnings and DB selection errors
- Create temporary registration directory and enforce strict code validation to prevent "FUCK OFF!" failures

## Testing
- `php -l game.php`
- `php -l pub.php`
- `php -l gres.php`


------
https://chatgpt.com/codex/tasks/task_b_689ca9cb921083258d04e5e8ef2900cd