### PR TITLE
fix: guard cluster notice access

### DIFF
--- a/game.php
+++ b/game.php
@@ -56,7 +56,7 @@ switch ($action) {
 
 
         $c = getcluster($usr['cluster']);
-        if ($c['notice'] != '') {
+        if ($c !== false && !empty($c['notice'])) {
             $info .= infobox('Cluster-Info', 'overview-cluster', nl2br($c['notice']), 'id');
         }
 #$info.=infobox('<b>ACHTUNG:</b> Multis keine Chance! Wer mehrere Accounts besitzt, wird gnadenlos gel&ouml;scht.');


### PR DESCRIPTION
## Summary
- prevent PHP warning when cluster data not found

## Testing
- `php -l game.php`


------
https://chatgpt.com/codex/tasks/task_b_689caf057b1c8325a81c811fbdea1960