### PR TITLE
Fix undefined password variable in cluster creation

### DIFF
--- a/cluster.php
+++ b/cluster.php
@@ -920,9 +920,9 @@ Ordner 3:<br />
         }
 
 
-        if (!(strlen($code) <= 12 and strlen($name) <= 48 and strlen($pwd) <= 16)) {
+        if (!(strlen($code) <= 12 and strlen($name) <= 48)) {
             $e = true;
-            $msg .= 'Bitte alle drei Felder ausf&uuml;llen!<br />';
+            $msg .= 'Bitte beide Felder ausf&uuml;llen!<br />';
         }
 
         if ($e == false) {


### PR DESCRIPTION
## Summary
- remove unused $pwd check and update message to prevent warnings

## Testing
- `php -l cluster.php`


------
https://chatgpt.com/codex/tasks/task_b_689cb0b72ff0832582c121bc8ca44160