### PR TITLE
Prevent undefined array key in item view

### DIFF
--- a/game.php
+++ b/game.php
@@ -351,11 +351,12 @@ switch ($action) {
         }
 
         $item = $_REQUEST['item'];
-        if (isavailh($item, $pc) != true && $pc[$item] < 1) {
+        $pcItemValue = $pc[$item] ?? null;
+        if ($pcItemValue === null || (isavailh($item, $pc) != true && $pcItemValue < 1)) {
             exit;
         }
         createlayout_top('HackTheNet - Deine Computer');
-        $val = $pc[$item];
+        $val = $pcItemValue;
         if ($item == 'ram') {
             $val = $ram_levels[$val];
         } elseif ($item == 'cpu') {


### PR DESCRIPTION
## Summary
- handle missing item keys before accessing a player's data in `game.php`

## Testing
- `php -l game.php`


------
https://chatgpt.com/codex/tasks/task_b_689cb8fc5a288325ae92491c57e304e5