### PR TITLE
fix: initialize avatar variable

### DIFF
--- a/user.php
+++ b/user.php
@@ -96,7 +96,7 @@ switch ($action) {
             $account = 'normal';
         }
 
-
+        $avatar = '';
         if (preg_match('#^https?://.*/.+#i', $usr['avatar'])) {
             $avatar = '<br />'.LF.'<img src="'.$usr['avatar'].'" alt="Avatar" />';
         }


### PR DESCRIPTION
## Summary
- ensure avatar variable is initialized to avoid PHP warning when user avatar unset

## Testing
- `php -l user.php`


------
https://chatgpt.com/codex/tasks/task_b_689cc5cd6b14832596a24db685afea9d