### PR TITLE
Use server time for page clock

### DIFF
--- a/global.js
+++ b/global.js
@@ -26,11 +26,18 @@ function fmtint(i) {
     return (i < 10 ? "0" + i : i);
 }
 
+var serverFormatter = new Intl.DateTimeFormat('de-DE', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZone: stz
+});
+
 function synchrclock() {
-    var now = new Date();
-    var c = new Date();
-    c.setTime(stm.getTime() + (now.getTime() - sltm.getTime()));
-    getLay("server-time").innerHTML = fmtint(c.getHours()) + ":" + fmtint(c.getMinutes()) + ":" + fmtint(c.getSeconds()) + " Uhr";
+    var now = new Date().getTime();
+    var serverTime = (stm * 1000) + (now - sltm);
+    getLay("server-time").innerHTML = serverFormatter.format(serverTime) + " Uhr";
 }
 function startsynchr() {
     setInterval(synchrclock, 1000);

--- a/layout.php
+++ b/layout.php
@@ -37,13 +37,14 @@ function basicheader($title)
     }
 
     $ts = time() + 1;
+    $tz = date_default_timezone_get();
     echo '<!DOCTYPE html>'."\n";
     echo '<html lang="de">' . "\n";
     echo '<head>' . "\n";
     echo '<meta charset="utf-8">' . "\n";
     echo '<title>' . $title . '</title>' . "\n";
     echo '<link rel="stylesheet" href="' . $STYLESHEET_BASEDIR . $stylesheet . '/style.css">' . "\n";
-    echo '<script>var stm=new Date(); stm.setTime(' . $ts . '000); var sltm=new Date();</script>' . "\n";
+    echo '<script>var stm=' . $ts . '; var stz="' . $tz . '"; var sltm=new Date().getTime();</script>' . "\n";
     echo '<script src="global.js" defer></script>' . "\n";
     echo '<link rel="icon" href="favicon.ico">' . "\n";
     echo $javascript;


### PR DESCRIPTION
## Summary
- expose server timezone string and timestamp
- format dynamic clock using server timezone via Intl API

## Testing
- `php -l layout.php`
- `node --check global.js`


------
https://chatgpt.com/codex/tasks/task_b_689ccab6baf483258cbbca52f9fd3e26