### PR TITLE
Use server time for page clock

### DIFF
--- a/global.js
+++ b/global.js
@@ -26,13 +26,21 @@ function fmtint(i) {
     return (i < 10 ? "0" + i : i);
 }
 
+var serverFormatter = new Intl.DateTimeFormat('de-DE', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZone: stz
+});
+
 function synchrclock() {
-    var now = new Date();
-    var c = new Date();
-    c.setTime(stm.getTime() + (now.getTime() - sltm.getTime()));
-    getLay("server-time").innerHTML = fmtint(c.getHours()) + ":" + fmtint(c.getMinutes()) + ":" + fmtint(c.getSeconds()) + " Uhr";
+    var now = new Date().getTime();
+    var serverTime = (stm * 1000) + (now - sltm);
+    getLay("server-time").innerHTML = serverFormatter.format(serverTime) + " Uhr";
 }
 function startsynchr() {
+    synchrclock();
     setInterval(synchrclock, 1000);
 }
 

--- a/layout.php
+++ b/layout.php
@@ -9,6 +9,15 @@ $bodytag = '';
 
 include_once('config.php');
 
+$server_tz = @file_get_contents('/etc/timezone');
+if ($server_tz !== false) {
+    $server_tz = trim($server_tz);
+}
+if ($server_tz === '' || $server_tz === false) {
+    $server_tz = date_default_timezone_get();
+}
+date_default_timezone_set($server_tz);
+
 function menu_entry($url, $text, $help = '', $em = '', $emclass = '', $selftags = false, $inatag = '')
 {
     // refaktorisierte Funktion *muaahaahhaahaaa*
@@ -29,7 +38,7 @@ function menu_entry($url, $text, $help = '', $em = '', $emclass = '', $selftags 
 
 function basicheader($title)
 {
-    global $usr, $javascript, $STYLESHEET, $bodytag, $stylesheets;
+    global $usr, $javascript, $STYLESHEET, $bodytag, $stylesheets, $server_tz;
     global $STYLESHEET_BASEDIR, $standard_stylesheet;
     $stylesheet = $STYLESHEET;
     if ($stylesheets[$stylesheet]['id'] == '' || $stylesheet == '') {
@@ -43,7 +52,7 @@ function basicheader($title)
     echo '<meta charset="utf-8">' . "\n";
     echo '<title>' . $title . '</title>' . "\n";
     echo '<link rel="stylesheet" href="' . $STYLESHEET_BASEDIR . $stylesheet . '/style.css">' . "\n";
-    echo '<script>var stm=new Date(); stm.setTime(' . $ts . '000); var sltm=new Date();</script>' . "\n";
+    echo '<script>var stm=' . $ts . '; var stz="' . $server_tz . '"; var sltm=new Date().getTime();</script>' . "\n";
     echo '<script src="global.js" defer></script>' . "\n";
     echo '<link rel="icon" href="favicon.ico">' . "\n";
     echo $javascript;


### PR DESCRIPTION
## Summary
- derive timezone from /etc/timezone and set as PHP default
- pass system timezone to frontend and start clock immediately

## Testing
- `php -l layout.php`
- `node --check global.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_b_689ccab6baf483258cbbca52f9fd3e26