### PR TITLE
Refactor worm to mysqli

### DIFF
--- a/worm.php
+++ b/worm.php
@@ -4,6 +4,8 @@ if (!defined('IN_HTN')) {
     die('Hacking attempt');
 }
 
+global $dbcon;
+
 $action = mt_rand(1, 3);
 
 switch ($action) {
@@ -11,11 +13,11 @@ switch ($action) {
     case 1: // Geld aus Clusterkasse eines Clusters mit mehr als einer Million Credits klauen
         $victim = db_query('SELECT * FROM clusters WHERE money>1000000 ORDER BY RAND() LIMIT 1;');
         if (!$victim) {
-            continue;
+            break;
         }
-        $victim = mysql_fetch_assoc($victim);
+        $victim = mysqli_fetch_assoc($victim);
         if ($victim['code'] == '') {
-            continue;
+            break;
         }
         $creds = (int)$victim['money'];
         $creds = floor($creds / 1.5);
@@ -24,68 +26,67 @@ switch ($action) {
             ).' Ein gef&auml;hrlicher Internet-Wurm hat '.$stolen.' Credits aus der Clusterkasse geklaut!'."\n";
         $victim['events'] = $ev.$victim['events'];
         db_query(
-            'UPDATE `clusters` SET `money`='.mysql_escape_string($creds).', `events`=\''.mysql_escape_string(
-                $victim['events']
-            ).'\' WHERE `id`=\''.mysql_escape_string($victim['id']).'\';'
+            'UPDATE `clusters` SET `money`=' . mysqli_real_escape_string($dbcon, $creds) .
+            ", `events`='" . mysqli_real_escape_string($dbcon, $victim['events']) .
+            "' WHERE `id`='" . mysqli_real_escape_string($dbcon, $victim['id']) . "';"
         );
-        echo mysql_error();
+        echo mysqli_error($dbcon);
         db_query(
-            'INSERT INTO logs SET type=\'worm_clmoney\', usr_id=\''.mysql_escape_string(
-                $victim['id']
-            ).'\', payload=\'stole '.mysql_escape_string($stolen).' credits from cluster '.mysql_escape_string(
-                $victim['id']
-            ).'\';'
+            'INSERT INTO logs SET type=\'worm_clmoney\', usr_id=\'' .
+            mysqli_real_escape_string($dbcon, $victim['id']) .
+            '\', payload=\'stole ' . mysqli_real_escape_string($dbcon, $stolen) .
+            ' credits from cluster ' . mysqli_real_escape_string($dbcon, $victim['id']) . '\';'
         );
         break;
 
     case 2: // PC von User aus dem oberen Teil der Rangliste blockieren
         $victim = db_query('SELECT * FROM users WHERE rank<=50 ORDER BY RAND() LIMIT 1;');
         if (!$victim) {
-            continue;
+            break;
         }
-        $victim = mysql_fetch_assoc($victim);
+        $victim = mysqli_fetch_assoc($victim);
         if ((int)$victim['id'] == 0) {
-            continue;
+            break;
         }
         #echo '<br>id='.$victim['id'];
-        $vpc = @mysql_fetch_assoc(
-            db_query('SELECT id,ip,name FROM pcs WHERE owner='.$victim['id'].' ORDER BY RAND() LIMIT 1;')
+        $vpc = @mysqli_fetch_assoc(
+            db_query('SELECT id,ip,name FROM pcs WHERE owner=' . $victim['id'] . ' ORDER BY RAND() LIMIT 1;')
         );
         $blocked = time() + 6 * 60 * 60;
-        db_query('UPDATE pcs SET blocked=\''.mysql_escape_string($blocked).'\' WHERE id='.$vpc['id'].';');
+        db_query('UPDATE pcs SET blocked=\'' . mysqli_real_escape_string($dbcon, $blocked) . '\' WHERE id=' . $vpc['id'] . ';');
         addsysmsg(
             $victim['id'],
             'Dein PC 10.47.'.$vpc['ip'].' ('.$vpc['name'].') wurde durch einen b&ouml;sartigen Wurm, der im Moment im Netz kursiert,
   bis '.nicetime($blocked).' blockiert!'
         );
         db_query(
-            'INSERT INTO logs SET type=\'worm_blockpc\', usr_id=\''.mysql_escape_string(
-                $victim['id']
-            ).'\', payload=\'blocked pc '.$vpc['id'].'\';'
+            'INSERT INTO logs SET type=\'worm_blockpc\', usr_id=\'' .
+            mysqli_real_escape_string($dbcon, $victim['id']) .
+            '\', payload=\'blocked pc ' . $vpc['id'] . '\';'
         );
         break;
 
     case 3: // PC von aktivem User aus dem Mittelfeld der Rangliste Credits schenken
         $ts = time() - 24 * 60 * 60;
         $victim = db_query(
-            'SELECT * FROM users WHERE (rank>50 AND login_time>'.mysql_escape_string($ts).') ORDER BY RAND() LIMIT 1;'
+            'SELECT * FROM users WHERE (rank>50 AND login_time>' . mysqli_real_escape_string($dbcon, $ts) . ') ORDER BY RAND() LIMIT 1;'
         );
-        echo mysql_error();
+        echo mysqli_error($dbcon);
         if (!$victim) {
-            continue;
+            break;
         }
-        $victim = mysql_fetch_assoc($victim);
+        $victim = mysqli_fetch_assoc($victim);
         if ((int)$victim['id'] == 0) {
-            continue;
+            break;
         }
         #echo '<br>id='.$victim['id'];
-        $vpc = @mysql_fetch_assoc(
-            db_query('SELECT id,ip,name,credits FROM pcs WHERE owner='.$victim['id'].' ORDER BY RAND() LIMIT 1;')
+        $vpc = @mysqli_fetch_assoc(
+            db_query('SELECT id,ip,name,credits FROM pcs WHERE owner=' . $victim['id'] . ' ORDER BY RAND() LIMIT 1;')
         );
         $plus = mt_rand(2000, 10000);
         $creds = $vpc['credits'] + $plus;
         db_query(
-            'UPDATE pcs SET credits=\''.mysql_escape_string($creds).'\' WHERE id='.mysql_escape_string($vpc['id']).';'
+            'UPDATE pcs SET credits=\'' . mysqli_real_escape_string($dbcon, $creds) . '\' WHERE id=' . mysqli_real_escape_string($dbcon, $vpc['id']) . ';'
         );
         addsysmsg(
             $victim['id'],
@@ -93,9 +94,10 @@ switch ($action) {
   die Summe von '.$plus.' Credits &uuml;berwiesen!'
         );
         db_query(
-            'INSERT INTO logs SET type=\'worm_pcsendmoney\', usr_id=\''.mysql_escape_string(
-                $victim['id']
-            ).'\', payload=\'gave '.mysql_escape_string($plus).' credits to pc '.mysql_escape_string($vpc['id']).'\';'
+            'INSERT INTO logs SET type=\'worm_pcsendmoney\', usr_id=\'' .
+            mysqli_real_escape_string($dbcon, $victim['id']) .
+            '\', payload=\'gave ' . mysqli_real_escape_string($dbcon, $plus) .
+            ' credits to pc ' . mysqli_real_escape_string($dbcon, $vpc['id']) . '\';'
         );
         break;
 


### PR DESCRIPTION
## Summary
- replace deprecated mysql_* calls with mysqli equivalents
- use break instead of continue to avoid warnings under PHP 8

## Testing
- `php -l worm.php`


------
https://chatgpt.com/codex/tasks/task_b_689ee2592e60832599083c2d0ee9b9fe