### PR TITLE
Fix theme injection PHP tags

### DIFF
--- a/cluster.php
+++ b/cluster.php
@@ -60,7 +60,8 @@ switch ($action) {
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="cluster">'."\n";
         echo '<h2>Cluster</h2>'."\n";
@@ -345,7 +346,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="cluster">
 <h2>Cluster</h2>'
@@ -540,7 +542,8 @@ function autosel(obj) { var i = (obj.name==\'pcip\' ? 1 : 0);
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="cluster">
 <h2>Cluster</h2>
@@ -635,7 +638,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="cluster">
 <h2>Cluster</h2>
@@ -775,7 +779,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="cluster">
 <h2>Cluster</h2>
@@ -871,7 +876,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
                 echo '<div class="content" id="cluster">
 <h2>Cluster l&ouml;schen</h2>
@@ -1025,7 +1031,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="error"><h3>Fehler</h3><p>'.$msg.'</p></div>';
             ?>
@@ -1098,7 +1105,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 #$r=db_query('SELECT id FROM users WHERE cluster='.mysql_escape_string($clusterid).';');
 #$members=mysql_num_rows($r);
@@ -1182,7 +1190,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 
             $members = '';
@@ -1389,7 +1398,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="cluster">'."\n";
             echo '<h2>Cluster</h2>'."\n";
@@ -1424,7 +1434,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="cluster-profile">
 <h2>Cluster-Profil</h2>
@@ -1569,7 +1580,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
                 echo '<div class="content" id="cluster">
 <h2>Cluster</h2>
@@ -1731,7 +1743,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="cluster">
 <h2>Cluster</h2>
@@ -1779,7 +1792,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="cluster">
 <h2>Cluster</h2>
@@ -1804,7 +1818,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="cluster">
 <h2>Cluster</h2>
@@ -1903,7 +1918,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="cluster-notice-saved">'."\n";
         echo '<h2>Cluster-Notiz</h2>'."\n";

--- a/game.php
+++ b/game.php
@@ -66,7 +66,8 @@ switch ($action) {
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 
 # Cluster-Mitgliedsbeitrag bezahlen:
@@ -214,7 +215,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 
         if ($pc['blocked'] > time()) {
@@ -383,7 +385,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="computer">'.LF.'<h2>Deine Computer</h2>'.LF.'<div class="error">'.LF.'<h3>Fehler</h3>'.LF.'<p>Dieses Item wurde nicht gefunden.</p>'.LF.'</div>'.LF.'</div>'."\n";
             ?>
@@ -398,7 +401,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         $val = $pcItemValue;
         if ($item == 'ram') {
@@ -625,7 +629,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="computer">'."\n";
         echo '<h2>Dein Computer</h2>'."\n";
@@ -828,7 +833,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
                     echo '<div id="computer" class="content">'."\n";
                     echo '<h2>Dein Computer</h2>'."\n";
@@ -914,7 +920,8 @@ createlayout_bottom();*/
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 
         echo '<div class="content" id="computer">
@@ -1082,7 +1089,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="computer">
 <h2>Deine Computer</h2>
@@ -1162,7 +1170,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         if ($usr['bigacc'] == 'yes') {
             $bigacc = '&nbsp;<a href="javascript:show_abook(\'pc\')">Adressbuch</a>';
@@ -1243,7 +1252,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content">
 <h2>&Uuml;berweisung</h2>
@@ -1476,7 +1486,8 @@ location.href=\'../game.php?mode=subnet&sid='.$sid.'&subnet=\'+s;
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="subnet">
 <h2>Subnet</h2>
@@ -1577,7 +1588,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         readfile('data/static/kb.html');
         ?>

--- a/mail.php
+++ b/mail.php
@@ -193,7 +193,8 @@ switch ($action) {
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         $link_inbox = '';
         $link_sysmsgs = '';
@@ -306,7 +307,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="messages">'.LF.'<h2>Messages</h2>'.LF.$notif;
         newmailform($_REQUEST['recip'], $_REQUEST['subject'], $_REQUEST['text']);
@@ -325,7 +327,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         $x = maillist('arc');
         echo '<div class="content" id="messages">
@@ -368,7 +371,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         $x = maillist('out');
         echo '<div class="content" id="messages">
@@ -569,7 +573,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             echo '<div class="content" id="messages">'.LF.'<h2>Messages</h2>'.LF.$err."\n";
             newmailform($_REQUEST['recip'], $_REQUEST['subject'], $_REQUEST['text'], false);
@@ -640,7 +645,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="messages">
 <h2>Messages</h2>
@@ -715,7 +721,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="messages">'.LF.'<h2>Messages</h2>'.LF;
         newmailform(
@@ -739,7 +746,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="messages">
 <h2>Messages</h2>
@@ -785,7 +793,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="messages">
 <h2>Messages</h2>
@@ -977,7 +986,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="messages">'."\n";
 #if(!$localhost) {

--- a/pub.php
+++ b/pub.php
@@ -27,7 +27,8 @@ function showdoc($fn, $te = '')
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
     $x = 'data/pubtxt/'.$fn;
     if (file_exists($x.'.txt')) {
@@ -77,7 +78,8 @@ switch ($action) {
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="register">
 <h2>Registrieren</h2>
@@ -127,7 +129,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="rules">
 <h2>Regelversto&szlig; gemeldet</h2>
@@ -231,7 +234,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 
             $pwd = generateMnemonicPassword();
@@ -292,7 +296,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         echo '<div class="content" id="register">
 <h2>Registrieren</h2>
@@ -425,7 +430,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
                 echo '<div class="content" id="register">
 <h2>Account aktivieren</h2>
@@ -440,7 +446,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
                 echo '<div class="content" id="register">
 <h2>Account aktivieren</h2>
@@ -527,7 +534,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 
         function stats($server)
@@ -622,7 +630,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
         include('data/pubtxt/startseite.php');
         ?>

--- a/ranking.php
+++ b/ranking.php
@@ -34,7 +34,8 @@ switch ($action) {
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 
         $updtime = nicetime((int)@file_get('data/calc-time.dat'));

--- a/user.php
+++ b/user.php
@@ -19,7 +19,8 @@ switch ($action) {
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
 
         echo '<div class="content" id="settings">
@@ -485,7 +486,8 @@ createlayout_bottom();
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
 <div class="container">
-<?php // /ZDE theme inject start ?>
+<?php // /ZDE theme inject start
+
 
             if ($a['gender'] == 'x') {
                 $geschl = '';


### PR DESCRIPTION
## Summary
- Keep ZDE theme injection comments inside PHP to avoid ending script blocks.
- Remove stray closing tags that caused syntax errors across multiple entry points.

## Testing
- `php -l pub.php`
- `php -l cluster.php game.php mail.php ranking.php user.php`


------
https://chatgpt.com/codex/tasks/task_b_689ef78bc1b48325be73ef5c95fa2dd2