### PR TITLE
feat: overhaul dashboard layout

### DIFF
--- a/game.php
+++ b/game.php
@@ -64,7 +64,11 @@ switch ($action) {
         createlayout_top('ZeroDayEmpire - &Uuml;bersicht');
 ?>
 <!-- ZDE theme inject -->
-<style>@import url("style.css");</style>
+<style>@import url("style.css");
+#computers li{position:relative}
+#computers li .tip{display:none;position:absolute;top:100%;left:0;background:#222;color:#fff;padding:4px;border-radius:3px;max-width:240px;font-size:12px;z-index:10}
+#computers li:hover .tip{display:block}
+</style>
 <div class="container">
 <?php // /ZDE theme inject start
 
@@ -137,21 +141,11 @@ switch ($action) {
             );
         }
 
-        $pcs_no_upgr = 0;
-        $a = explode(',', $usr['pcs']);
-        $pccnt = count($a); # Anzahl PCs
-
         $da = false;
         $sql = db_query('SELECT * FROM pcs WHERE owner='.mysql_escape_string($usr['id']).';');
         while ($x = mysql_fetch_assoc($sql)) {
             if ($x['points'] < 1024) {
                 processupgrades($x);
-                if ((int)@mysql_num_rows(
-                        @db_query('SELECT `id` FROM `upgrades` WHERE pc=\''.mysql_escape_string($x['id']).'\';')
-                    ) == 0
-                ) {
-                    $pcs_no_upgr++;
-                }
             }
             if ($da !== true) {
                 $tmp = isavailh('da', $x);
@@ -161,43 +155,82 @@ switch ($action) {
             }
         }
         setuserval('da_avail', ($da == true ? 'yes' : 'no'));
+        echo $notif.$info;
+        ?>
 
-        echo '<div class="content" id="overview">
-<h2>&Uuml;bersicht</h2>
-'.$notif.'
-'.$info;
+<section class="features" aria-label="Dashboard">
+  <article class="card span-6">
+    <h3 class="tight">Willkommen, <?php echo safeentities($usr['name']); ?></h3>
+    <p class="muted">Dein Syndikat wartet auf Befehle.</p>
+  </article>
 
+  <article class="card span-6">
+    <h3>&Uuml;bersicht</h3>
+    <div class="strip" style="margin-top:10px; grid-template-columns:repeat(auto-fit,minmax(140px,1fr))">
+      <div class="kpi"><div class="label"><strong>Guthaben:</strong></div><div class="value"><span><?php echo $bucks; ?></span> <span class="unit">CR</span></div></div>
+      <div class="kpi"><div class="label"><strong>Punkte:</strong></div><div class="value"><span><?php echo $usr['points']; ?></span> <span class="unit">Punkte</span></div></div>
+    </div>
+  </article>
 
+  <article class="card span-6" id="computers">
+    <h3>Computer</h3>
+    <ul class="muted" style="list-style:none; padding-left:0; margin:10px 0 0 0">
+      <li><a href="game.php?m=pc&amp;sid=<?php echo $sid; ?>"><strong><?php echo safeentities($pc['name']); ?></strong> (10.47.<?php echo $pc['ip']; ?>)</a></li>
+      <li data-item="cpu"><?php echo idtoname('cpu'); ?>: <?php echo $cpu_levels[$pc['cpu']]; ?> Mhz<div class="tip"></div></li>
+      <li data-item="ram"><?php echo idtoname('ram'); ?>: <?php echo $ram_levels[$pc['ram']]; ?> MB<div class="tip"></div></li>
+      <li data-item="lan"><?php echo idtoname('lan'); ?>: Level <?php echo $pc['lan']; ?><div class="tip"></div></li>
+      <li data-item="mm"><?php echo idtoname('mm'); ?>: Version <?php echo $pc['mm']; ?><div class="tip"></div></li>
+      <li data-item="bb"><?php echo idtoname('bb'); ?>: Version <?php echo $pc['bb']; ?><div class="tip"></div></li>
+      <li data-item="fw"><?php echo idtoname('fw'); ?>: Version <?php echo $pc['fw']; ?><div class="tip"></div></li>
+      <li data-item="av"><?php echo idtoname('av'); ?>: Version <?php echo $pc['av']; ?><div class="tip"></div></li>
+      <li data-item="ids"><?php echo idtoname('ids'); ?>: Level <?php echo $pc['ids']; ?><div class="tip"></div></li>
+    </ul>
+  </article>
+
+  <article class="card span-6" id="cluster">
+    <h3>Cluster</h3>
+    <?php if ($c !== false) { ?>
+      <ul class="muted" style="list-style:none; padding-left:0; margin:10px 0 0 0">
+        <li><strong><?php echo safeentities($c['name']); ?></strong></li>
+        <li>Punkte: <?php echo number_format($c['points'],0,',','.'); ?></li>
+        <li>Mitglieder: <?php echo $c['members']; ?></li>
+        <li>Geld: <?php echo number_format($c['money'],0,',','.'); ?> CR</li>
+      </ul>
+    <?php } else { ?>
+      <p class="muted">Du bist in keinem Cluster.</p>
+    <?php } ?>
+  </article>
+</section>
+
+<script>
+document.querySelectorAll('#computers li[data-item]').forEach(li => {
+  li.addEventListener('mouseenter', async () => {
+    if (li.dataset.loaded) return;
+    const item = li.getAttribute('data-item');
+    const tip = li.querySelector('.tip');
+    try {
+      const res = await fetch(`game.php?m=item&item=${item}&sid=<?php echo $sid; ?>`);
+      const html = await res.text();
+      const div = document.createElement('div');
+      div.innerHTML = html;
+      const content = div.querySelector('.content');
+      tip.textContent = content ? content.textContent.trim() : div.textContent.trim();
+    } catch (e) {
+      tip.textContent = '';
+    }
+    li.dataset.loaded = '1';
+  });
+});
+</script>
+
+<?php
         if ($newtotal > 0) {
             echo '<div id="overview-messages">'."\n";
             echo '<h3>Messages</h3>'."\n";
-            echo '<p>Du hast <strong>'.$newtotal.' ungelesene Nachricht'.($newtotal == 1 ? '' : 'en').'</strong>.</p>', "\n";
-            echo '<p><a href="mail.php?m=start&amp;sid='.$sid.'">Gehe zu den Nachrichten</a></p>', "\n";
+            echo '<p>Du hast <strong>'.$newtotal.' ungelesene Nachricht'.($newtotal == 1 ? '' : 'en').'</strong>.</p>'."\n";
+            echo '<p><a href="mail.php?m=start&amp;sid='.$sid.'">Gehe zu den Nachrichten</a></p>'."\n";
             echo '</div>';
         }
-
-        if ($pcs_no_upgr > 0) {
-            echo '<div id="overview-computer">'."\n";
-            echo '<h3>Computer</h3>'."\n";
-            echo '<p>Auf <strong>'.$pcs_no_upgr.' Computer'.($pcs_no_upgr == 1 ? '' : 'n').'</strong> l&auml;uft im Moment <strong>kein Upgrade</strong>; hier solltest du evtl. ein neues Upgrade starten.</p>'."\n"; /* FIXME Fallunterscheidung */
-            echo '<p><a href="game.php?m=pcs&amp;sid='.$sid.'">Gehe zu den Computern</a></p>'."\n";
-            echo '</div>';
-        }
-
-        $usr['points'] = number_format($usr['points'], 0, ',', '.');
-        echo '<div id="overview-ranking">
-<h3>Situation</h3>
-<p>Du besitzt im Moment <strong>'.$usr['points'].' Punkte</strong>, aufgeteilt auf <strong>'.$pccnt.' Computer</strong>. Damit bist du auf dem <strong>'.$usr['rank'].'. Platz</strong> in der Gesamtwertung.</p>
-<p><a href="ranking.php?m=ranking&amp;sid='.$sid.'">Gehe zur Rangliste</a></p>';
-        if ($c !== false) {
-            $c['points'] = number_format($c['points'], 0, ',', '.');
-            echo '<p>Dein Cluster besitzt <strong>'.$c['points'].' Punkte</strong>. Damit ist dein Cluster auf dem <strong>'.$c['rank'].'. Platz</strong> in der Gesamtwertung.</p>
-<p><a href="ranking.php?m=ranking&amp;type=cluster&amp;sid='.$sid.'">Gehe zur Cluster-Rangliste</a></p>';
-        }
-
-        echo '</div>
-</div>';
-
         ?>
 </div>
 <!-- /ZDE theme inject -->

--- a/style.css
+++ b/style.css
@@ -70,6 +70,7 @@ a{color:inherit; text-decoration:none}
 .kpi{ background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.01)); border:1px solid var(--border); padding:16px; border-radius:var(--radius); display:flex; align-items:center; justify-content:space-between }
 .kpi .label{ color:var(--muted); font-size:13px }
 .kpi .value{ font-weight:800; font-size:clamp(18px,3vw,28px) }
+.kpi .value .unit{ font-weight:400; font-size:clamp(12px,2vw,16px) }
 
 /* Footer */
 footer{ color:var(--muted); border-top:1px solid var(--border); margin-top:52px }


### PR DESCRIPTION
## Summary
- modernize game.php start page with dashboard-style layout
- show user credits, computer specs and cluster stats in card widgets
- remove obsolete 'Situation' section and expand computer info with hover tooltips
- fix overview card sizing and typography; drop redundant computer warning block

## Testing
- `php -l game.php`


------
https://chatgpt.com/codex/tasks/task_b_689efb35b9748325858aa6aeaa89455d