### PR TITLE
Modernize hardware upgrade defaults

### DIFF
--- a/battle.php
+++ b/battle.php
@@ -759,7 +759,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
                 addsysmsg(
                     $usrid,
                     '<b>Spionage-Bericht von 10.47.'.$remote['ip'].'</b> Besitzer: [usr='.$owner['id'].']'.$owner['name'].'[/usr]<br />
-    Prozessor = '.$cpu_levels[$remote['cpu']].' Mhz,<br />Arbeitsspeicher = '.$ram_levels[$remote['ram']].' MB RAM,<br /> MoneyMarket = v'.$remote['mm'].',<br /> BucksBunker = v'.$remote['bb'].',<br />
+    Prozessor = '.$cpu_names[$remote['cpu']].',<br />Arbeitsspeicher = '.$ram_levels[$remote['ram']].' MB RAM,<br /> MoneyMarket = v'.$remote['mm'].',<br /> BucksBunker = v'.$remote['bb'].',<br />
     Firewall = v'.$remote['fw'].',<br /> Anti-Virus-Programm = v'.$remote['av'].',<br /> IDS = v'.$remote['ids'].',<br />
     IPS = v'.$remote['ips'].',<br /> Malware Kit = v'.$remote['mk'].',<br /> Trojaner = v'.$remote['trojan'].',<br /> SDK = v'.$remote['sdk'].',<br />
     Remote Hijack = v'.$remote['rh'].',<br /> Distributed Attack = '.(int)isavailh('da', $remote)
@@ -981,7 +981,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
             function smash($key)
             {
                 global $STYLESHEET, $REMOTE_FILES_DIR, $DATADIR, $remote, $local, $target, $local2, $remote2;
-                global $cpu_levels, $ram_levels, $msg, $success, $noticed, $usr, $usrid;
+                global $cpu_levels, $ram_levels, $cpu_names, $msg, $success, $noticed, $usr, $usrid;
                 $defend = getDefend('($remote[\'av\']+$remote[\'fw\'])*25');
                 $attack = getAttack('($local[\'sdk\']+$local[\'mk\'])*30');
                 $tmp = getsuccess($attack, $defend, 45);
@@ -1028,7 +1028,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
                         $remote2[$key] = $newval;
                         savepc($target, $remote2);
                         if ($key == 'cpu') {
-                            $newval = $cpu_levels[$newval];
+                            $newval = $cpu_names[$newval];
                         }
                         $s .= idtoname($key).' wurde zerst&ouml;rt auf '.$newval.'!<br />';
                         echo idtoname($key).' zerst&ouml;rt auf '.$newval.'!</span><br />';

--- a/game.php
+++ b/game.php
@@ -186,7 +186,7 @@ switch ($action) {
       <h3>Computer</h3>
       <ul class="muted" style="list-style:none; padding-left:0; margin:10px 0 0 0">
         <li><a href="game.php?m=pc&amp;sid=<?php echo $sid; ?>"><strong><?php echo safeentities($pc['name']); ?></strong> (10.47.<?php echo $pc['ip']; ?>)</a></li>
-        <li data-item="cpu"><?php echo idtoname('cpu'); ?>: <?php echo $cpu_levels[$pc['cpu']]; ?> Mhz<?php echo overview_upgrade_link('cpu'); ?><div class="tip"></div></li>
+        <li data-item="cpu"><?php echo idtoname('cpu'); ?>: <?php echo $cpu_names[$pc['cpu']]; ?><?php echo overview_upgrade_link('cpu'); ?><div class="tip"></div></li>
         <li data-item="ram"><?php echo idtoname('ram'); ?>: <?php echo $ram_levels[$pc['ram']]; ?> MB<?php echo overview_upgrade_link('ram'); ?><div class="tip"></div></li>
         <li data-item="lan"><?php echo idtoname('lan'); ?>: Level <?php echo $pc['lan']; ?><?php echo overview_upgrade_link('lan'); ?><div class="tip"></div></li>
       </ul>
@@ -282,14 +282,14 @@ createlayout_bottom();
 
         function showinfo($id, $txt, $val = -1)
         {
-            global $pc, $sid, $pcid, $usrid, $ram_levels, $cpu_levels;
+            global $pc, $sid, $pcid, $usrid, $ram_levels, $cpu_levels, $cpu_names;
             if ($val == -1) {
                 $val = $pc[$id];
             }
             if ($id == 'ram') {
                 $val = $ram_levels[$val];
             } elseif ($id == 'cpu') {
-                $val = $cpu_levels[$val];
+                $val = $cpu_names[$val];
             }
             $name = idtoname($id);
             if ($val && $val != '0.0') {
@@ -367,7 +367,7 @@ createlayout_bottom();
 <div id="computer-essentials">
 <h3>Essentials</h3>
 <p>';
-        showinfo('cpu', '%v Mhz');
+        showinfo('cpu', '%v');
         br();
         showinfo('ram', '%v MB RAM');
         br();
@@ -456,7 +456,7 @@ createlayout_bottom();
         if ($item == 'ram') {
             $val = $ram_levels[$val];
         } elseif ($item == 'cpu') {
-            $val = $cpu_levels[$val];
+            $val = $cpu_names[$val];
         } else {
             if (strlen((string)$val) == 1) {
                 $val = $val.'.0';

--- a/gres.php
+++ b/gres.php
@@ -179,41 +179,66 @@ if ($localhost) {
 }
 
 $cpu_levels = array(
-    0 => 120,
-    1 => 266,
-    2 => 300,
-    3 => 450,
-    4 => 600,
-    5 => 800,
-    6 => 1000,
-    7 => 1200,
-    8 => 1500,
-    9 => 1800,
-    10 => 2000,
-    11 => 2200,
-    12 => 2400,
-    13 => 2600,
-    14 => 2800,
-    15 => 3000,
-    16 => 3200,
-    17 => 3400,
-    18 => 3600,
-    19 => 3800,
-    20 => 4000,
-    21 => 4400,
+    0 => 1200,
+    1 => 1400,
+    2 => 1600,
+    3 => 1800,
+    4 => 2000,
+    5 => 2200,
+    6 => 2400,
+    7 => 2600,
+    8 => 2800,
+    9 => 3000,
+    10 => 3200,
+    11 => 3400,
+    12 => 3600,
+    13 => 3800,
+    14 => 4000,
+    15 => 4200,
+    16 => 4400,
+    17 => 4600,
+    18 => 4800,
+    19 => 5000,
+    20 => 5200,
+    21 => 5400,
+);
+
+$cpu_names = array(
+    0 => 'Single-Core 1200',
+    1 => 'Single-Core 1400',
+    2 => 'Single-Core 1600',
+    3 => 'Single-Core 1800',
+    4 => 'Dual-Core 2000',
+    5 => 'Dual-Core 2200',
+    6 => 'Dual-Core 2400',
+    7 => 'Dual-Core 2600',
+    8 => 'Dual-Core 2800',
+    9 => 'Dual-Core 3000',
+    10 => 'Dual-Core 3200',
+    11 => 'Quad-Core 3400',
+    12 => 'Quad-Core 3600',
+    13 => 'Quad-Core 3800',
+    14 => 'Quad-Core 4000',
+    15 => 'Quad-Core 4200',
+    16 => 'Quad-Core 4400',
+    17 => 'Quad-Core 4600',
+    18 => 'Quad-Core 4800',
+    19 => 'Quad-Core 5000',
+    20 => 'Quad-Core 5200',
+    21 => 'Quad-Core 5400',
 );
 
 $ram_levels = array(
-    0 => 16,
-    1 => 32,
-    2 => 64,
-    3 => 128,
-    4 => 256,
-    5 => 512,
-    6 => 1024,
-    7 => 2048,
-    8 => 3072,
-    9 => 4096,
+    0 => 1024,
+    1 => 2048,
+    2 => 3072,
+    3 => 4096,
+    4 => 5120,
+    5 => 6144,
+    6 => 7168,
+    7 => 8192,
+    8 => 9216,
+    9 => 10240,
 );
 
 define('DPH_ADS', 22, false);
@@ -1036,18 +1061,18 @@ function itemnextlevel($id, $curlevel)
 
 function formatitemlevel($id, $val)
 { //--------------------- FORMAT ITEM LEVEL ----------------------
-    global $cpu_levels, $ram_levels;
+    global $cpu_levels, $ram_levels, $cpu_names;
     if ($id == 'ram') {
         $val = $ram_levels[$val];
     } elseif ($id == 'cpu') {
-        $val = $cpu_levels[$val];
+        $val = $cpu_names[$val];
     } elseif ((float)$val == 0) {
         $val = '0.0';
     } elseif (strlen((string)$val) == 1 || $val == 10) {
         $val = $val.'.0';
     }
     if ($id == 'cpu') {
-        $sval = $val.' Mhz';
+        $sval = $val;
     } elseif ($id == 'ram') {
         $sval = $val.' MB RAM';
     } else {


### PR DESCRIPTION
## Summary
- Refresh CPU upgrade options with modern Single-, Dual-, and Quad-Core labels
- Expand RAM upgrade tiers to start at 1GB and scale to 10GB
- Show new CPU names throughout gameplay and reports

## Testing
- `php -l gres.php`
- `php -l game.php`
- `php -l battle.php`


------
https://chatgpt.com/codex/tasks/task_b_689f0e598fbc8325930a4b1f2c3b7865