### PR TITLE
Trigger ranking recalculation when overdue

### DIFF
--- a/ranking.php
+++ b/ranking.php
@@ -38,7 +38,14 @@ switch ($action) {
 
 
 
-        $updtime = nicetime((int)@file_get('data/calc-time.dat'));
+        $next_update = (int)@file_get('data/calc-time.dat');
+        if ($next_update < time() && !file_exists('data/calc-running.dat')) {
+            ob_start();
+            include __DIR__ . '/calc_points.php';
+            ob_end_clean();
+            $next_update = (int)@file_get('data/calc-time.dat');
+        }
+        $updtime = nicetime($next_update);
         echo '<div class="content" id="ranking">
 <h2>Rangliste</h2>
 <div class="submenu">


### PR DESCRIPTION
## Summary
- Recalculate ranking points on demand when the stored update time has expired.

## Testing
- `php -l ranking.php`
- `php -l calc_points.php`


------
https://chatgpt.com/codex/tasks/task_b_689f152657f483258cd2f97b78292da2