### PR TITLE
Limit item tooltip to description text

### DIFF
--- a/game.php
+++ b/game.php
@@ -244,8 +244,13 @@ document.querySelectorAll('#computers li[data-item]').forEach(li => {
       const html = await res.text();
       const div = document.createElement('div');
       div.innerHTML = html;
-      const content = div.querySelector('.content');
-      tip.textContent = content ? content.textContent.trim() : div.textContent.trim();
+      const content = div.querySelector('#computer-item');
+      let text = '';
+      if (content) {
+        const ps = content.querySelectorAll('p');
+        text = ps.length >= 2 ? ps[1].textContent.trim() : ps.length === 1 ? ps[0].textContent.trim() : '';
+      }
+      tip.textContent = text;
     } catch (e) {
       tip.textContent = '';
     }


### PR DESCRIPTION
## Summary
- Restrict dashboard item tooltips to only show the description paragraph from the item page

## Testing
- `php -l game.php`


------
https://chatgpt.com/codex/tasks/task_b_689f15c3b7608325945ebf72e1f8441a