### PR TITLE
Replace HackTheNet references with ZeroDayEmpire

### DIFF
--- a/DATABASE.DUMP.SQL
+++ b/DATABASE.DUMP.SQL
@@ -7,8 +7,8 @@ SET FOREIGN_KEY_CHECKS=0;
 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS;
 SET UNIQUE_CHECKS=0;
 
-CREATE DATABASE IF NOT EXISTS `htn_server1` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-USE htn_server1;
+CREATE DATABASE IF NOT EXISTS `zde_server1` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE zde_server1;
 
 # --------------------------------------------------------
 
@@ -148,7 +148,7 @@ CREATE TABLE `clusters` (
 # Daten für Tabelle `clusters`
 #
 
-INSERT INTO `clusters` VALUES (1, 'TestCluster', '=HTNTC=', ' 00:11 Der Cluster wird durch TestUser gegr&uuml;ndet!', 1, 1, NULL, 30, NULL, NULL, 'Wichtig', 'Allgemein', 'Alte Beiträge', 'yes', 1, NULL, 0, 0, 0);
+INSERT INTO `clusters` VALUES (1, 'TestCluster', '=ZDETC=', ' 00:11 Der Cluster wird durch TestUser gegr&uuml;ndet!', 1, 1, NULL, 30, NULL, NULL, 'Wichtig', 'Allgemein', 'Alte Beiträge', 'yes', 1, NULL, 0, 0, 0);
 INSERT INTO `clusters` VALUES (2, 'Administratoren', '::root::', '24.08. um 00:13 [usr=2]Administrator2[/usr] erh&auml;lt durch [usr=1]Administrator[/usr] den Status LiteAdmin.\n24.08. um 00:13 [usr=2]Administrator2[/usr] tritt dem Cluster bei.\n 00:12 Der Cluster wird durch Administrator gegr&uuml;ndet!', 1, 2, NULL, 13036, NULL, NULL, 'Wichtig', 'Allgemein', 'Alte Beiträge', 'yes', 0, NULL, 0, 0, 0);
 
 # --------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# HackTheNet 2 — Quellcode (modernisiert)
+# ZeroDayEmpire 2 — Quellcode (modernisiert)
 
-> **Version:** htn2src.2.0‑RC6 (15.08.2025)
+> **Version:** zde2src.2.0‑RC6 (15.08.2025)
 >
 > **Kompatibilität:** PHP 8.3+, MariaDB 10.x (oder kompatible MySQL‑Server), moderner Webserver (Apache/Nginx)
 
@@ -25,7 +25,7 @@ Creative Commons **BY‑NC‑SA 2.0 DE** (Namensnennung – nicht kommerziell
 
 ## 🚀 Schnellstart (Kurzfassung)
 
-1) **Quellcode** ins Webroot deployen (z. B. `/var/www/htn2`).  
+1) **Quellcode** ins Webroot deployen (z. B. `/var/www/zde2`).  
 2) **Dump importieren**: `DATABASE.DUMP.mariadb10.sql` importiert **Datenbank & Tabellen**.  
 3) **DB‑Benutzer anlegen & berechtigen** (falls noch nicht vorhanden).  
 4) **`config.php` setzen**: Host, Benutzername, Kennwort und DB‑Name (bzw. Prefix/Suffix).  
@@ -41,8 +41,8 @@ Creative Commons **BY‑NC‑SA 2.0 DE** (Namensnennung – nicht kommerziell
 Kopiere das Projekt in dein Webserver‑Verzeichnis, z. B.:
 
 ```bash
-sudo mkdir -p /var/www/htn2
-sudo rsync -a . /var/www/htn2/
+sudo mkdir -p /var/www/zde2
+sudo rsync -a . /var/www/zde2/
 ```
 
 Richte ggf. eine virtuelle Host‑Konfiguration ein (Apache/Nginx), sodass die Domain auf den Ordner zeigt.
@@ -55,16 +55,16 @@ Richte ggf. eine virtuelle Host‑Konfiguration ein (Apache/Nginx), sodass die D
 
 ```sql
 -- in der MariaDB‑Shell (z. B. via: sudo mariadb)
-CREATE USER IF NOT EXISTS 'htn_user'@'localhost' IDENTIFIED BY 'EinStarkesPasswort!';
-CREATE DATABASE IF NOT EXISTS `htn_server1` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-GRANT ALL PRIVILEGES ON `htn_server1`.* TO 'htn_user'@'localhost';
+CREATE USER IF NOT EXISTS 'zde_user'@'localhost' IDENTIFIED BY 'EinStarkesPasswort!';
+CREATE DATABASE IF NOT EXISTS `zde_server1` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+GRANT ALL PRIVILEGES ON `zde_server1`.* TO 'zde_user'@'localhost';
 FLUSH PRIVILEGES;
 ```
 
 Danach Import über CLI:
 
 ```bash
-mysql -u htn_user -p htn_server1 < DATABASE.DUMP.mariadb10.sql
+mysql -u zde_user -p zde_server1 < DATABASE.DUMP.mariadb10.sql
 ```
 
 **Variante B: Dump als Admin importieren (erzeugt DB), dann Benutzer berechtigen**
@@ -74,15 +74,15 @@ mysql -u htn_user -p htn_server1 < DATABASE.DUMP.mariadb10.sql
 sudo mysql < DATABASE.DUMP.mariadb10.sql
 
 # Danach Benutzer anlegen und berechtigen (in der MariaDB‑Shell):
-CREATE USER IF NOT EXISTS 'htn_user'@'localhost' IDENTIFIED BY 'EinStarkesPasswort!';
-GRANT ALL PRIVILEGES ON `htn_server1`.* TO 'htn_user'@'localhost';
+CREATE USER IF NOT EXISTS 'zde_user'@'localhost' IDENTIFIED BY 'EinStarkesPasswort!';
+GRANT ALL PRIVILEGES ON `zde_server1`.* TO 'zde_user'@'localhost';
 FLUSH PRIVILEGES;
 ```
 
 **Alternative: phpMyAdmin**
 
 - Melde dich als Admin an, öffne **Import** und wähle `DATABASE.DUMP.mariadb10.sql` aus.  
-- Falls noch kein Benutzer existiert, unter **Benutzerkonten** → **Benutzerkonto hinzufügen** → Berechtigungen für Datenbank `htn_server1` vergeben.
+- Falls noch kein Benutzer existiert, unter **Benutzerkonten** → **Benutzerkonto hinzufügen** → Berechtigungen für Datenbank `zde_server1` vergeben.
 
 ### 3. Anwendung konfigurieren (`config.php`)
 
@@ -94,12 +94,12 @@ $db_use_this_values = true;
 
 // Datenbank‑Zugangsdaten
 $db_host = 'localhost';
-$db_username = 'htn_user';
+$db_username = 'zde_user';
 $db_password = 'EinStarkesPasswort!';
 
 // Datenbankname wird i. d. R. aus Prefix + Suffix gebildet:
-$database_prefix = 'htn_server';
-$database_suffix = '1'; // ergibt 'htn_server1'
+$database_prefix = 'zde_server';
+$database_suffix = '1'; // ergibt 'zde_server1'
 ```
 
 > Hinweis: Wenn du einen anderen DB‑Namen verwendest, passe `suffix` entsprechend an **oder** stelle sicher, dass die Anwendung auf die korrekte Datenbank zeigt.
@@ -109,11 +109,11 @@ $database_suffix = '1'; // ergibt 'htn_server1'
 Nur schreibpflichtige Verzeichnisse (z. B. `data/`) erhalten Schreibrechte für den Webserver‑User. Beispiel (Debian/Ubuntu mit `www-data`):
 
 ```bash
-sudo chown -R www-data:www-data /var/www/htn2/data
+sudo chown -R www-data:www-data /var/www/zde2/data
 # Verzeichnisse: 750 (rwx für Owner, rx für Gruppe)
-find /var/www/htn2/data -type d -exec chmod 750 {} \;
+find /var/www/zde2/data -type d -exec chmod 750 {} \;
 # Dateien: 640 (rw für Owner, r für Gruppe)
-find /var/www/htn2/data -type f -exec chmod 640 {} \;
+find /var/www/zde2/data -type f -exec chmod 640 {} \;
 ```
 
 Wenn mehrere Systemnutzer deployen, kannst du eine gemeinsame Gruppe verwenden und `770/660` wählen.
@@ -168,4 +168,4 @@ Rufe die Site im Browser auf. Initial stehen Test‑Accounts zur Verfügung (z.�
 
 ## 💡 Beiträge
 
-Verbesserungen oder Fixes willkommen! Reiche Änderungen als Archiv (ZIP/TAR.GZ) an htn2code@hackthenet.org ein, damit sie ggf. auf der offiziellen Seite veröffentlicht werden.
+Verbesserungen oder Fixes willkommen! Reiche Änderungen als Archiv (ZIP/TAR.GZ) an zde2code@ZeroDayEmpire.org ein, damit sie ggf. auf der offiziellen Seite veröffentlicht werden.

--- a/abook.php
+++ b/abook.php
@@ -5,7 +5,7 @@
  **/
 
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = false;
 include('ingame.php');
 

--- a/battle.php
+++ b/battle.php
@@ -4,7 +4,7 @@
  * Alle Angriffe werden hier drin abgehandelt
  **/
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = true;
 include('ingame.php');
 
@@ -47,7 +47,7 @@ function fill(s) {
 
             $bigacc = '<br /><a href="#codebox" onclick="show_abook(\'pc\')">Adressbuch</a>';
         }
-        createlayout_top('HackTheNet - Operation Center');
+        createlayout_top('ZeroDayEmpire - Operation Center');
         echo '<div class="content" id="attacks">';
         echo '<h2>Operation Center</h2>';
 
@@ -152,7 +152,7 @@ function fill(s) {
             exit;
         }
 
-        createlayout_top('HackTheNet - Operation Center');
+        createlayout_top('ZeroDayEmpire - Operation Center');
         echo '<div class="content" id="attacks">';
         echo '<h2>Operation Center</h2>';
         echo '<div id="attacks-attack2">';
@@ -581,7 +581,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
 </script>';
 
         $bodytag = ' onload="anim(1)"';
-        createlayout_top('HackTheNet - Operation Center', false, false);
+        createlayout_top('ZeroDayEmpire - Operation Center', false, false);
         echo '<div class="content" id="attacks">';
         echo '<h2>Operation Center</h2>';
         echo '<div id="attacks-attack3">';
@@ -719,7 +719,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
             if ($success != 0) {
                 $usr['newmail'] += 1;
             }
-            createlayout_top('HackTheNet - Operation Center');
+            createlayout_top('ZeroDayEmpire - Operation Center');
             if ($success != 0) {
                 $usr['newmail'] -= 1;
             }
@@ -784,7 +784,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
                     $t = 45;
                 }
 
-                createlayout_top('HackTheNet - Operation Center');
+                createlayout_top('ZeroDayEmpire - Operation Center');
                 echo '<div class="content" id="attacks">';
                 echo '<h2>Operation Center</h2>';
                 echo '<div id="attacks-attack4">';
@@ -832,7 +832,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
                     $success = $tmp['success'];
                     $noticed = $tmp['noticed'];
 
-                    createlayout_top('HackTheNet - Operation Center');
+                    createlayout_top('ZeroDayEmpire - Operation Center');
                     echo '<div class="content" id="attacks">';
                     echo '<h2>Operation Center</h2>';
                     echo '<div id="attacks-attack4">';
@@ -909,7 +909,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
                         $remote['credits'] = $remote2['credits'];
                     }
 
-                    createlayout_top('HackTheNet - Operation Center');
+                    createlayout_top('ZeroDayEmpire - Operation Center');
                     echo '<div class="content" id="attacks">';
                     echo '<h2>Operation Center</h2>';
                     echo '<div id="attacks-attack4">';
@@ -988,7 +988,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
                 $success = $tmp['success'];
                 $noticed = $tmp['noticed'];
 
-                createlayout_top('HackTheNet - Operation Center');
+                createlayout_top('ZeroDayEmpire - Operation Center');
                 echo '<div class="content" id="attacks">';
                 echo '<h2>Operation Center</h2>';
                 echo '<div id="attacks-attack4">';
@@ -1080,7 +1080,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
                 $t = 60;
             }
 
-            createlayout_top('HackTheNet - Operation Center');
+            createlayout_top('ZeroDayEmpire - Operation Center');
             echo '<div class="content" id="attacks">';
             echo '<h2>Operation Center</h2>';
             echo '<div id="attacks-attack4">';
@@ -1140,7 +1140,7 @@ location.replace(\'battle.php?m=opc&sid='.$sid.'\');
             }
             #echo 'defend = '.$defend.'<br>attack = '.$attack;
             #exit;
-            createlayout_top('HackTheNet - Operation Center');
+            createlayout_top('ZeroDayEmpire - Operation Center');
             echo '<div class="content" id="attacks">';
             echo '<h2>Operation Center</h2>';
             echo '<div id="attacks-attack4">';

--- a/calc_points.php
+++ b/calc_points.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('IN_HTN')) {
+if (!defined('IN_ZDE')) {
     die('Hacking attempt');
 }
 

--- a/cboard.php
+++ b/cboard.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 define('EDIT_TIME_OUT', 12 * 60 * 60, false);
 
 $FILE_REQUIRES_PC = false;
@@ -28,7 +28,7 @@ switch ($action) {
 
     case 'board': // ------------------------ BOARD ---------------------------------
 
-        createlayout_top('HackTheNet - Cluster-Board');
+        createlayout_top('ZeroDayEmpire - Cluster-Board');
         echo '<div class="content" id="cluster-board">'.LF;
         echo '<h2>Cluster-Board</h2>'.LF;
         echo '<p><a href="cboard.php?sid='.$sid.'&amp;a=newthreadform">Neuen Beitrag erstellen</a></p>'."\n";
@@ -244,7 +244,7 @@ switch ($action) {
 
     case 'newthreadform': // ------------------------ NEW THREAD FORM ---------------------------------
 
-        createlayout_top('HackTheNet - Cluster-Board - Beitrag erstellen');
+        createlayout_top('ZeroDayEmpire - Cluster-Board - Beitrag erstellen');
         echo '<div class="content" id="cluster-board">'.LF.'<h2>Cluster-Board</h2>'.LF.'<div id="cluster-board-newthread">'.LF.'<h3>Beitrag erstellen</h3>'."\n";
         showform();
         echo '</div>'.LF.'</div>'."\n";
@@ -289,7 +289,7 @@ switch ($action) {
 
     case 'showthread': // ------------------------ SHOW THREAD ---------------------------------
 
-        createlayout_top('HackTheNet - Cluster-Board - Beitrag');
+        createlayout_top('ZeroDayEmpire - Cluster-Board - Beitrag');
         echo '<div class="content" id="cluster-board-post">'."\n";
         echo '<h2>Cluster-Board</h2>'."\n";
 

--- a/cluster.php
+++ b/cluster.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = false;
 include('ingame.php');
 

--- a/config.php
+++ b/config.php
@@ -1,7 +1,7 @@
 <?php
 
 # DATENBANKEN:
-$database_prefix = 'htn_server';
+$database_prefix = 'zde_server';
 $database_suffix = '';
 
 $db_use_this_values = false;
@@ -13,14 +13,14 @@ $db_password = '';
 $standard_stylesheet = 'crystal';
 $stylesheets['standard'] = array(
     'id' => 'standard',
-    'name' => 'HackTheNet Standard',
-    'author' => 'HackTheNet-Team',
+    'name' => 'ZeroDayEmpire Standard',
+    'author' => 'ZeroDayEmpire-Team',
     'bigacc' => 'no',
 );
 $stylesheets['crystal'] = array(
     'id' => 'crystal',
-    'name' => 'HackTheNet Crystal',
-    'author' => 'HackTheNet-Team',
+    'name' => 'ZeroDayEmpire Crystal',
+    'author' => 'ZeroDayEmpire-Team',
     'bigacc' => 'no',
 );
 $stylesheets['konsole'] = array('id' => 'konsole', 'name' => 'Konsole', 'author' => 'Volkmar', 'bigacc' => 'yes');

--- a/data/pubtxt/credits.txt
+++ b/data/pubtxt/credits.txt
@@ -1,9 +1,9 @@
 <div id="public-team" class="content">
-<h2>HackTheNet-Team</h2>
+<h2>ZeroDayEmpire-Team</h2>
 
 <div id="team-kings">
 <h3>Wichtig!</h3>
-<p>Der Quellcode dieses Spiels stammt im Original von <a href="http://www.hackthenet.org/">www.hackthenet.org</a>.
+<p>Der Quellcode dieses Spiels stammt im Original von <a href="http://www.ZeroDayEmpire.org/">www.ZeroDayEmpire.org</a>.
 Dieser Hinweis darft nicht entfernt werden!</p>
 
 </div>

--- a/data/pubtxt/faq.txt
+++ b/data/pubtxt/faq.txt
@@ -1,8 +1,8 @@
 <div class="content" id="faq">
 <h2>FAQ</h2>
 <div id="faq-faq1">
-<h3>Was ist HackTheNet?</h3>
-<p>HackTheNet ist ein browserbasiertes Onlinespiel.<br />
+<h3>Was ist ZeroDayEmpire?</h3>
+<p>ZeroDayEmpire ist ein browserbasiertes Onlinespiel.<br />
 Ihr bekommt einen Computer in einem virtuellen (nicht existenten) Netzwerk
 zugewiesen. Hier steht ab jetzt die Expansion im Vordergrund.<br />
 Entwickelt euren Prozessor und andere Items weiter und verdient Geld. Bald seid Ihr soweit, dass
@@ -17,7 +17,7 @@ Ihr Waffen (Viren, Trojaner etc.) entwickeln und gegen eure Feinde einsetzen k&o
 <p>Einen Internet-Zugang, einen Browser (ab Internet Explorer 5.0, ab Netscape 6.0, ab Opera 5.0 oder Mozilla, alle Versionen) und eine funktionierende Email-Adresse.</p>
 </div>
 <div id="faq-faq4">
-<h3>In welcher Programmier-Sprache wurde Hack the Net geschrieben?</h3>
-<p>HackTheNet wurde komplett in PHP realisiert. Der Quellcode umfasst insgesamt &uuml;ber 330.000 Zeichen auf etwa 8.000 Zeilen!</p>
+<h3>In welcher Programmier-Sprache wurde ZeroDayEmpire geschrieben?</h3>
+<p>ZeroDayEmpire wurde komplett in PHP realisiert. Der Quellcode umfasst insgesamt &uuml;ber 330.000 Zeichen auf etwa 8.000 Zeilen!</p>
 </div>
 </div>

--- a/data/pubtxt/regok.txt
+++ b/data/pubtxt/regok.txt
@@ -1,5 +1,5 @@
 <h3>Registrierung</h3>
 <p><strong>Herzlichen Gl&uuml;ckwunsch!</strong></p>
-<p>In diesem Moment ist eine Email mit den Zugangsdaten f&uuml;r deinen neuen Hack the Net-Account
+<p>In diesem Moment ist eine Email mit den Zugangsdaten f&uuml;r deinen neuen ZeroDayEmpire-Account
 an dich unterwegs! Bevor du den Account nutzen kannst, musst du ihn aktivieren. Wie das geht, steht
 in der Email. Ruf also jetzt deine Emails ab und in ein paar Minuten bist du dabei!</p>

--- a/data/pubtxt/rules.txt
+++ b/data/pubtxt/rules.txt
@@ -28,15 +28,15 @@ Es ist dagegen erwünscht, dass Fehler bei den Admins oder im Forum gemeldet wer
 In diesem Fall bestehen allerdings keinerlei Entlohnungs-Ansprüche!</p>
 
 <h3>&sect;4 - Bots</h3>
-<p>Es ist strengstens verboten, jegliche Seiten von HackTheNet mit anderen Programmen außer dem Browser abzurufen,
+<p>Es ist strengstens verboten, jegliche Seiten von ZeroDayEmpire mit anderen Programmen außer dem Browser abzurufen,
 dies bezieht sich besonders auf sogenannte Bots oder auch andere Tools, die das Webinterface ersetzen sollen.<br />
 
 a) Erlaubt sind jegliche öffentlich zugänglichen Browser wie Mozilla, Opera, Netscape, Internet Explorer, Konqueror oder Lynx.
 <br />
-b) Jegliche Aufrufe von Fremdquellen (Seiten oder Programme), die nicht auf dem HTN-Server liegen, sind verboten,
+b) Jegliche Aufrufe von Fremdquellen (Seiten oder Programme), die nicht auf dem ZDE-Server liegen, sind verboten,
 Hierzu zählen insbesondere Seiten/Tools die vereinfachtes einloggen oder Verwalten von Accounts ermöglichen.
 <br />
-c) Auch das programmtechnische oder manuelle Verändern von Links, die vom HTN-Server stammen, ist illegal.
+c) Auch das programmtechnische oder manuelle Verändern von Links, die vom ZDE-Server stammen, ist illegal.
 </p>
 
 <h3>&sect;5 - Eingriffe in die Spieltechnik</h3>
@@ -65,7 +65,7 @@ Eine Entscheidung eines Admins bei einem Anderen zu hinterfragen um ein anderes 
 
 <h3>&sect;9 - Eigentumsverhältnisse</h3>
 <p>Jeder Account, sowie die Credits und Computer sind virtuelle Gegenstände im Spiel
-und bleiben Eigentum der HTN-Admins. Sie werden den Spielern nur leihweise zur Verfügung gestellt.
+und bleiben Eigentum der ZDE-Admins. Sie werden den Spielern nur leihweise zur Verfügung gestellt.
 Das Verkaufen von Accounts oder Credits ist allerdings erlaubt.</p>
 
 <h3>&sect; 10 - Haftungsausschluss</h3>

--- a/data/pubtxt/startseite.php
+++ b/data/pubtxt/startseite.php
@@ -1,10 +1,10 @@
-<div class="content" id="public"><h2>Willkommen bei HackTheNet</h2>
+<div class="content" id="public"><h2>Willkommen bei ZeroDayEmpire</h2>
 
     <?php
     $s1 = 'checked="checked" ';
     $usrname = $pwd = $sv = '';
-    if (isset($_COOKIE['htnLoginData4']) && substr_count($_COOKIE['htnLoginData4'], "|") == 2) {
-        list($server, $usrnameVal, $pwdVal) = explode("|", $_COOKIE['htnLoginData4']);
+    if (isset($_COOKIE['zdeLoginData4']) && substr_count($_COOKIE['zdeLoginData4'], "|") == 2) {
+        list($server, $usrnameVal, $pwdVal) = explode("|", $_COOKIE['zdeLoginData4']);
         $var = "s".$server;
         $$var = "checked=\"checked\" ";
         $usrname = "value=\"".htmlspecialchars($usrnameVal, ENT_QUOTES)."\" ";
@@ -53,10 +53,10 @@
         <p><a href="pub.php?d=stats">Ausführliche Statistik</a></p></div>
 
     <div class="info"><h3>Aktuelle News</h3>
-        <p>Besuchen Sie auch das Original dieses Spiels auf <a href="http://www.hackthenet.org/">www.hackthenet.org</a>.
+        <p>Besuchen Sie auch das Original dieses Spiels auf <a href="http://www.ZeroDayEmpire.org/">www.ZeroDayEmpire.org</a>.
         </p>
         <p>Auf unseren Seiten sehen wir den Internet Explorer nicht so gerne, wir empfehlen statt dessen den <a
                 href="http://www.mozilla.org/products/firefox/">Firefox</a>.</p>
-        <p>Der offizielle HTN-IRC-Channel ist im Freakarea-Netzwerk zu finden! Server ist <em>irc.freakarea.net</em>,
-            Channel <em>#hackthenet</em>.
+        <p>Der offizielle ZDE-IRC-Channel ist im Freakarea-Netzwerk zu finden! Server ist <em>irc.freakarea.net</em>,
+            Channel <em>#ZeroDayEmpire</em>.
     </div>

--- a/distrattack.php
+++ b/distrattack.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = false;
 include('ingame.php');
 
@@ -40,7 +40,7 @@ return window.confirm(\'Die Distributed Attack wirklich abbrechen?\');
 }
 </script>';
 
-createlayout_top('HackTheNet - Cluster - Distributed Attacks');
+createlayout_top('ZeroDayEmpire - Cluster - Distributed Attacks');
 echo '<div class="content" id="cluster">'."\n";
 echo '<h2>Cluster</h2>'."\n";
 

--- a/doku/default/_abook_htn.html
+++ b/doku/default/_abook_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page abook.htn</title>
+			<title>Docs for page abook.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/abook.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/abook.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">
@@ -66,13 +66,13 @@
 			|										<a href="#sec-functions">Functions</a>
 					</div>
 		<div class="info-box-body">	
-			<a name="defineIN_HTN"><!-- --></a>
+			<a name="defineIN_ZDE"><!-- --></a>
 <div class="oddrow">
 	
 	<div>
 		<img src="../media/images/Constant.png" />
 		<span class="const-title">
-			<span class="const-name">IN_HTN</span> = 1
+			<span class="const-name">IN_ZDE</span> = 1
 			(line <span class="line-number">8</span>)
 		</span>
 	</div>

--- a/doku/default/_battle_htn.html
+++ b/doku/default/_battle_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page battle.htn</title>
+			<title>Docs for page battle.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/battle.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/battle.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_cboard_htn.html
+++ b/doku/default/_cboard_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page cboard.htn</title>
+			<title>Docs for page cboard.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/cboard.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/cboard.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_cluster_htn.html
+++ b/doku/default/_cluster_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page cluster.htn</title>
+			<title>Docs for page cluster.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/cluster.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/cluster.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_distrattack_htn.html
+++ b/doku/default/_distrattack_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page distrattack.htn</title>
+			<title>Docs for page distrattack.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/distrattack.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/distrattack.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_game_htn.html
+++ b/doku/default/_game_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page game.htn</title>
+			<title>Docs for page game.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/game.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/game.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_layout_php.html
+++ b/doku/default/_layout_php.html
@@ -139,7 +139,7 @@
 		<span class="method-name">
 			createlayout_top
 		</span>
-					([<span class="var-type">mixed</span>&nbsp;<span class="var-name">$title</span> = <span class="var-default">'HackTheNet'</span>], [<span class="var-type">mixed</span>&nbsp;<span class="var-name">$nomenu</span> = <span class="var-default">false</span>], [<span class="var-type">mixed</span>&nbsp;<span class="var-name">$pads</span> = <span class="var-default">true</span>])
+					([<span class="var-type">mixed</span>&nbsp;<span class="var-name">$title</span> = <span class="var-default">'ZeroDayEmpire'</span>], [<span class="var-type">mixed</span>&nbsp;<span class="var-name">$nomenu</span> = <span class="var-default">false</span>], [<span class="var-type">mixed</span>&nbsp;<span class="var-name">$pads</span> = <span class="var-default">true</span>])
 			</div>
 
 		

--- a/doku/default/_login_htn.html
+++ b/doku/default/_login_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page login.htn</title>
+			<title>Docs for page login.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/login.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/login.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_mail_htn.html
+++ b/doku/default/_mail_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page mail.htn</title>
+			<title>Docs for page mail.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/mail.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/mail.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_pub_htn.html
+++ b/doku/default/_pub_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page pub.htn</title>
+			<title>Docs for page pub.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/pub.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/pub.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_ranking_htn.html
+++ b/doku/default/_ranking_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page ranking.htn</title>
+			<title>Docs for page ranking.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/ranking.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/ranking.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_search_htn.html
+++ b/doku/default/_search_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page search.htn</title>
+			<title>Docs for page search.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/search.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/search.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_secret_htn.html
+++ b/doku/default/_secret_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page secret.htn</title>
+			<title>Docs for page secret.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/secret.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/secret.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_user_htn.html
+++ b/doku/default/_user_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page user.htn</title>
+			<title>Docs for page user.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/user.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/user.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/default/_usrimg_htn.html
+++ b/doku/default/_usrimg_htn.html
@@ -3,14 +3,14 @@
   <html xmlns="http://www.w3.org/1999/xhtml">
 		<head>
 			<!-- template designed by Marco Von Ballmoos -->
-			<title>Docs for page usrimg.htn</title>
+			<title>Docs for page usrimg.zde</title>
 			<link rel="stylesheet" href="../media/stylesheet.css" />
 			<meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'/>
 		</head>
 		<body>
 			<div class="page-body">			
 
-<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/usrimg.htn</h2>
+<h2 class="file-name"><img src="../media/images/Page_logo.png" alt="File" style="vertical-align: middle">/usrimg.zde</h2>
 
 <a name="sec-description"></a>
 <div class="info-box">

--- a/doku/elementindex.html
+++ b/doku/elementindex.html
@@ -48,10 +48,10 @@
 	<dl>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">abook.htn</span>
+			<span class="include-title">abook.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_abook_htn.html">abook.htn</a> in abook.htn</div>
+			<div class="index-item-details"><a href="default/_abook_zde.html">abook.zde</a> in abook.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -72,14 +72,14 @@
 			<span class="method-title">addtoattacklist</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functionaddtoattacklist">addtoattacklist()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functionaddtoattacklist">addtoattacklist()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">admin_list</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_abook_htn.html#functionadmin_list">admin_list()</a> in abook.htn</div>
+			<div class="index-item-details"><a href="default/_abook_zde.html#functionadmin_list">admin_list()</a> in abook.zde</div>
 					</dd>
 		</dl>
 	<a name="b"></a>
@@ -112,31 +112,31 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">battle.htn</span>
+			<span class="include-title">battle.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html">battle.htn</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html">battle.zde</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">battle_table</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionbattle_table">battle_table()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionbattle_table">battle_table()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">br</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionbr">br()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionbr">br()</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">buildinfo</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionbuildinfo">buildinfo()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionbuildinfo">buildinfo()</a> in game.zde</div>
 					</dd>
 		</dl>
 	<a name="c"></a>
@@ -169,17 +169,17 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">cboard.htn</span>
+			<span class="include-title">cboard.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html">cboard.htn</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html">cboard.zde</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">checknick</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#functionchecknick">checknick()</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#functionchecknick">checknick()</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -197,10 +197,10 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">cluster.htn</span>
+			<span class="include-title">cluster.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html">cluster.htn</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html">cluster.zde</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -214,7 +214,7 @@
 			<span class="method-title">conventlist</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionconventlist">conventlist()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionconventlist">conventlist()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -319,42 +319,42 @@
 			<span class="method-title">cvCodeToString</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functioncvCodeToString">cvCodeToString()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functioncvCodeToString">cvCodeToString()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_BEISTAND</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_BEISTAND">CV_BEISTAND</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_BEISTAND">CV_BEISTAND</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_NAP</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_NAP">CV_NAP</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_NAP">CV_NAP</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_PEACE</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_PEACE">CV_PEACE</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_PEACE">CV_PEACE</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_WAR</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_WAR">CV_WAR</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_WAR">CV_WAR</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_WING</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_WING">CV_WING</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_WING">CV_WING</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -390,7 +390,7 @@
 			<span class="method-title">deactivate</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functiondeactivate">deactivate()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functiondeactivate">deactivate()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -422,10 +422,10 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">distrattack.htn</span>
+			<span class="include-title">distrattack.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_distrattack_htn.html">distrattack.htn</a> in distrattack.htn</div>
+			<div class="index-item-details"><a href="default/_distrattack_zde.html">distrattack.zde</a> in distrattack.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
@@ -475,7 +475,7 @@
 			<span class="const-title">EDIT_TIME_OUT</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#defineEDIT_TIME_OUT">EDIT_TIME_OUT</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#defineEDIT_TIME_OUT">EDIT_TIME_OUT</a> in cboard.zde</div>
 					</dd>
 		</dl>
 	<a name="f"></a>
@@ -511,7 +511,7 @@
 			<span class="method-title">formatText</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionformatText">formatText()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionformatText">formatText()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -530,31 +530,31 @@
 	<dl>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">game.htn</span>
+			<span class="include-title">game.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html">game.htn</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html">game.zde</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">generateMnemonicPassword</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#functiongenerateMnemonicPassword">generateMnemonicPassword()</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#functiongenerateMnemonicPassword">generateMnemonicPassword()</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">getAttack</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functiongetAttack">getAttack()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functiongetAttack">getAttack()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">getcheckedmail_str</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functiongetcheckedmail_str">getcheckedmail_str()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functiongetcheckedmail_str">getcheckedmail_str()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -575,7 +575,7 @@
 			<span class="method-title">getDefend</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functiongetDefend">getDefend()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functiongetDefend">getDefend()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -666,7 +666,7 @@
 			<span class="method-title">getsuccess</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functiongetsuccess">getsuccess()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functiongetsuccess">getsuccess()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -745,7 +745,7 @@
 			<span class="method-title">idtotext</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_secret_htn.html#functionidtotext">idtotext()</a> in secret.htn</div>
+			<div class="index-item-details"><a href="default/_secret_zde.html#functionidtotext">idtotext()</a> in secret.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -759,7 +759,7 @@
 			<span class="method-title">infobox</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functioninfobox">infobox()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functioninfobox">infobox()</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -770,10 +770,10 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
-			<span class="const-title">IN_HTN</span>
+			<span class="const-title">IN_ZDE</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_abook_htn.html#defineIN_HTN">IN_HTN</a> in abook.htn</div>
+			<div class="index-item-details"><a href="default/_abook_zde.html#defineIN_ZDE">IN_ZDE</a> in abook.zde</div>
 							<div class="index-item-description">Adressbuch-Verwaltung für Extended Account</div>
 					</dd>
 			<dt class="field">
@@ -867,28 +867,28 @@
 			<span class="method-title">listboard</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionlistboard">listboard()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionlistboard">listboard()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">list_items</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_abook_htn.html#functionlist_items">list_items()</a> in abook.htn</div>
+			<div class="index-item-details"><a href="default/_abook_zde.html#functionlist_items">list_items()</a> in abook.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">LoadSmilies</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionLoadSmilies">LoadSmilies()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionLoadSmilies">LoadSmilies()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">login.htn</span>
+			<span class="include-title">login.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_login_htn.html">login.htn</a> in login.htn</div>
+			<div class="index-item-details"><a href="default/_login_zde.html">login.zde</a> in login.zde</div>
 					</dd>
 		</dl>
 	<a name="m"></a>
@@ -903,21 +903,21 @@
 			<span class="method-title">maillist</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functionmaillist">maillist()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functionmaillist">maillist()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">mail_format_text</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functionmail_format_text">mail_format_text()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functionmail_format_text">mail_format_text()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">mail.htn</span>
+			<span class="include-title">mail.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html">mail.htn</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html">mail.zde</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
@@ -959,7 +959,7 @@
 			<span class="method-title">mmitem</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionmmitem">mmitem()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionmmitem">mmitem()</a> in game.zde</div>
 					</dd>
 		</dl>
 	<a name="n"></a>
@@ -974,14 +974,14 @@
 			<span class="method-title">newmailcount</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functionnewmailcount">newmailcount()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functionnewmailcount">newmailcount()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">newmailform</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functionnewmailform">newmailform()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functionnewmailform">newmailform()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1023,7 +1023,7 @@
 			<span class="method-title">nocluster</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionnocluster">nocluster()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionnocluster">nocluster()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1049,10 +1049,10 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">pub.htn</span>
+			<span class="include-title">pub.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html">pub.htn</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html">pub.zde</a> in pub.zde</div>
 					</dd>
 		</dl>
 	<a name="r"></a>
@@ -1078,17 +1078,17 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">ranking.htn</span>
+			<span class="include-title">ranking.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_ranking_htn.html">ranking.htn</a> in ranking.htn</div>
+			<div class="index-item-details"><a href="default/_ranking_zde.html">ranking.zde</a> in ranking.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">REG_CODE_LEN</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#defineREG_CODE_LEN">REG_CODE_LEN</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#defineREG_CODE_LEN">REG_CODE_LEN</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1167,7 +1167,7 @@
 			<span class="method-title">savemycluster</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionsavemycluster">savemycluster()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionsavemycluster">savemycluster()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1192,17 +1192,17 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">search.htn</span>
+			<span class="include-title">search.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_search_htn.html">search.htn</a> in search.htn</div>
+			<div class="index-item-details"><a href="default/_search_zde.html">search.zde</a> in search.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">secret.htn</span>
+			<span class="include-title">secret.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_secret_htn.html">secret.htn</a> in secret.htn</div>
+			<div class="index-item-details"><a href="default/_secret_zde.html">secret.zde</a> in secret.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1223,28 +1223,28 @@
 			<span class="method-title">showdoc</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#functionshowdoc">showdoc()</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#functionshowdoc">showdoc()</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">showform</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionshowform">showform()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionshowform">showform()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">showinfo</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionshowinfo">showinfo()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionshowinfo">showinfo()</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">show_beitrag</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionshow_beitrag">show_beitrag()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionshow_beitrag">show_beitrag()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1258,7 +1258,7 @@
 			<span class="method-title">smash</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functionsmash">smash()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functionsmash">smash()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -1272,14 +1272,14 @@
 			<span class="method-title">stats</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#functionstats">stats()</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#functionstats">stats()</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">stat_list_item</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionstat_list_item">stat_list_item()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionstat_list_item">stat_list_item()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1308,14 +1308,14 @@
 			<span class="method-title">transmit2_mail_list</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functiontransmit2_mail_list">transmit2_mail_list()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functiontransmit2_mail_list">transmit2_mail_list()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">transmit3_addbox</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functiontransmit3_addbox">transmit3_addbox()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functiontransmit3_addbox">transmit3_addbox()</a> in mail.zde</div>
 					</dd>
 		</dl>
 	<a name="u"></a>
@@ -1344,7 +1344,7 @@
 			<span class="method-title">updredir</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionupdredir">updredir()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionupdredir">updredir()</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
@@ -1355,17 +1355,17 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">user.htn</span>
+			<span class="include-title">user.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_user_htn.html">user.htn</a> in user.htn</div>
+			<div class="index-item-details"><a href="default/_user_zde.html">user.zde</a> in user.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">usrimg.htn</span>
+			<span class="include-title">usrimg.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_usrimg_htn.html">usrimg.htn</a> in usrimg.htn</div>
+			<div class="index-item-details"><a href="default/_usrimg_zde.html">usrimg.zde</a> in usrimg.zde</div>
 					</dd>
 		</dl>
 	<a name="w"></a>
@@ -1409,7 +1409,7 @@
 			<span class="method-title">xpcinfo</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionxpcinfo">xpcinfo()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionxpcinfo">xpcinfo()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>

--- a/doku/elementindex_default.html
+++ b/doku/elementindex_default.html
@@ -45,10 +45,10 @@
 	<dl>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">abook.htn</span>
+			<span class="include-title">abook.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_abook_htn.html">abook.htn</a> in abook.htn</div>
+			<div class="index-item-details"><a href="default/_abook_zde.html">abook.zde</a> in abook.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -69,14 +69,14 @@
 			<span class="method-title">addtoattacklist</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functionaddtoattacklist">addtoattacklist()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functionaddtoattacklist">addtoattacklist()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">admin_list</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_abook_htn.html#functionadmin_list">admin_list()</a> in abook.htn</div>
+			<div class="index-item-details"><a href="default/_abook_zde.html#functionadmin_list">admin_list()</a> in abook.zde</div>
 					</dd>
 		</dl>
 	<a name="b"></a>
@@ -109,31 +109,31 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">battle.htn</span>
+			<span class="include-title">battle.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html">battle.htn</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html">battle.zde</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">battle_table</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionbattle_table">battle_table()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionbattle_table">battle_table()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">br</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionbr">br()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionbr">br()</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">buildinfo</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionbuildinfo">buildinfo()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionbuildinfo">buildinfo()</a> in game.zde</div>
 					</dd>
 		</dl>
 	<a name="c"></a>
@@ -166,17 +166,17 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">cboard.htn</span>
+			<span class="include-title">cboard.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html">cboard.htn</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html">cboard.zde</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">checknick</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#functionchecknick">checknick()</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#functionchecknick">checknick()</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -194,10 +194,10 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">cluster.htn</span>
+			<span class="include-title">cluster.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html">cluster.htn</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html">cluster.zde</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -211,7 +211,7 @@
 			<span class="method-title">conventlist</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionconventlist">conventlist()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionconventlist">conventlist()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -316,42 +316,42 @@
 			<span class="method-title">cvCodeToString</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functioncvCodeToString">cvCodeToString()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functioncvCodeToString">cvCodeToString()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_BEISTAND</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_BEISTAND">CV_BEISTAND</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_BEISTAND">CV_BEISTAND</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_NAP</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_NAP">CV_NAP</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_NAP">CV_NAP</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_PEACE</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_PEACE">CV_PEACE</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_PEACE">CV_PEACE</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_WAR</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_WAR">CV_WAR</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_WAR">CV_WAR</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">CV_WING</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#defineCV_WING">CV_WING</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#defineCV_WING">CV_WING</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -387,7 +387,7 @@
 			<span class="method-title">deactivate</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functiondeactivate">deactivate()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functiondeactivate">deactivate()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -419,10 +419,10 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">distrattack.htn</span>
+			<span class="include-title">distrattack.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_distrattack_htn.html">distrattack.htn</a> in distrattack.htn</div>
+			<div class="index-item-details"><a href="default/_distrattack_zde.html">distrattack.zde</a> in distrattack.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
@@ -472,7 +472,7 @@
 			<span class="const-title">EDIT_TIME_OUT</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#defineEDIT_TIME_OUT">EDIT_TIME_OUT</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#defineEDIT_TIME_OUT">EDIT_TIME_OUT</a> in cboard.zde</div>
 					</dd>
 		</dl>
 	<a name="f"></a>
@@ -508,7 +508,7 @@
 			<span class="method-title">formatText</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionformatText">formatText()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionformatText">formatText()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -527,31 +527,31 @@
 	<dl>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">game.htn</span>
+			<span class="include-title">game.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html">game.htn</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html">game.zde</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">generateMnemonicPassword</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#functiongenerateMnemonicPassword">generateMnemonicPassword()</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#functiongenerateMnemonicPassword">generateMnemonicPassword()</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">getAttack</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functiongetAttack">getAttack()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functiongetAttack">getAttack()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">getcheckedmail_str</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functiongetcheckedmail_str">getcheckedmail_str()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functiongetcheckedmail_str">getcheckedmail_str()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -572,7 +572,7 @@
 			<span class="method-title">getDefend</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functiongetDefend">getDefend()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functiongetDefend">getDefend()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -663,7 +663,7 @@
 			<span class="method-title">getsuccess</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functiongetsuccess">getsuccess()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functiongetsuccess">getsuccess()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -742,7 +742,7 @@
 			<span class="method-title">idtotext</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_secret_htn.html#functionidtotext">idtotext()</a> in secret.htn</div>
+			<div class="index-item-details"><a href="default/_secret_zde.html#functionidtotext">idtotext()</a> in secret.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -756,7 +756,7 @@
 			<span class="method-title">infobox</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functioninfobox">infobox()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functioninfobox">infobox()</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -767,10 +767,10 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
-			<span class="const-title">IN_HTN</span>
+			<span class="const-title">IN_ZDE</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_abook_htn.html#defineIN_HTN">IN_HTN</a> in abook.htn</div>
+			<div class="index-item-details"><a href="default/_abook_zde.html#defineIN_ZDE">IN_ZDE</a> in abook.zde</div>
 							<div class="index-item-description">Adressbuch-Verwaltung für Extended Account</div>
 					</dd>
 			<dt class="field">
@@ -864,28 +864,28 @@
 			<span class="method-title">listboard</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionlistboard">listboard()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionlistboard">listboard()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">list_items</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_abook_htn.html#functionlist_items">list_items()</a> in abook.htn</div>
+			<div class="index-item-details"><a href="default/_abook_zde.html#functionlist_items">list_items()</a> in abook.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">LoadSmilies</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionLoadSmilies">LoadSmilies()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionLoadSmilies">LoadSmilies()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">login.htn</span>
+			<span class="include-title">login.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_login_htn.html">login.htn</a> in login.htn</div>
+			<div class="index-item-details"><a href="default/_login_zde.html">login.zde</a> in login.zde</div>
 					</dd>
 		</dl>
 	<a name="m"></a>
@@ -900,21 +900,21 @@
 			<span class="method-title">maillist</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functionmaillist">maillist()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functionmaillist">maillist()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">mail_format_text</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functionmail_format_text">mail_format_text()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functionmail_format_text">mail_format_text()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">mail.htn</span>
+			<span class="include-title">mail.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html">mail.htn</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html">mail.zde</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
@@ -956,7 +956,7 @@
 			<span class="method-title">mmitem</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionmmitem">mmitem()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionmmitem">mmitem()</a> in game.zde</div>
 					</dd>
 		</dl>
 	<a name="n"></a>
@@ -971,14 +971,14 @@
 			<span class="method-title">newmailcount</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functionnewmailcount">newmailcount()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functionnewmailcount">newmailcount()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">newmailform</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functionnewmailform">newmailform()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functionnewmailform">newmailform()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1020,7 +1020,7 @@
 			<span class="method-title">nocluster</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionnocluster">nocluster()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionnocluster">nocluster()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1046,10 +1046,10 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">pub.htn</span>
+			<span class="include-title">pub.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html">pub.htn</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html">pub.zde</a> in pub.zde</div>
 					</dd>
 		</dl>
 	<a name="r"></a>
@@ -1075,17 +1075,17 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">ranking.htn</span>
+			<span class="include-title">ranking.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_ranking_htn.html">ranking.htn</a> in ranking.htn</div>
+			<div class="index-item-details"><a href="default/_ranking_zde.html">ranking.zde</a> in ranking.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
 			<span class="const-title">REG_CODE_LEN</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#defineREG_CODE_LEN">REG_CODE_LEN</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#defineREG_CODE_LEN">REG_CODE_LEN</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1164,7 +1164,7 @@
 			<span class="method-title">savemycluster</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionsavemycluster">savemycluster()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionsavemycluster">savemycluster()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1189,17 +1189,17 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">search.htn</span>
+			<span class="include-title">search.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_search_htn.html">search.htn</a> in search.htn</div>
+			<div class="index-item-details"><a href="default/_search_zde.html">search.zde</a> in search.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">secret.htn</span>
+			<span class="include-title">secret.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_secret_htn.html">secret.htn</a> in secret.htn</div>
+			<div class="index-item-details"><a href="default/_secret_zde.html">secret.zde</a> in secret.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1220,28 +1220,28 @@
 			<span class="method-title">showdoc</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#functionshowdoc">showdoc()</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#functionshowdoc">showdoc()</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">showform</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionshowform">showform()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionshowform">showform()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">showinfo</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionshowinfo">showinfo()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionshowinfo">showinfo()</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">show_beitrag</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cboard_htn.html#functionshow_beitrag">show_beitrag()</a> in cboard.htn</div>
+			<div class="index-item-details"><a href="default/_cboard_zde.html#functionshow_beitrag">show_beitrag()</a> in cboard.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1255,7 +1255,7 @@
 			<span class="method-title">smash</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_battle_htn.html#functionsmash">smash()</a> in battle.htn</div>
+			<div class="index-item-details"><a href="default/_battle_zde.html#functionsmash">smash()</a> in battle.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
@@ -1269,14 +1269,14 @@
 			<span class="method-title">stats</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_pub_htn.html#functionstats">stats()</a> in pub.htn</div>
+			<div class="index-item-details"><a href="default/_pub_zde.html#functionstats">stats()</a> in pub.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">stat_list_item</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionstat_list_item">stat_list_item()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionstat_list_item">stat_list_item()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
@@ -1305,14 +1305,14 @@
 			<span class="method-title">transmit2_mail_list</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functiontransmit2_mail_list">transmit2_mail_list()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functiontransmit2_mail_list">transmit2_mail_list()</a> in mail.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>
 			<span class="method-title">transmit3_addbox</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_mail_htn.html#functiontransmit3_addbox">transmit3_addbox()</a> in mail.htn</div>
+			<div class="index-item-details"><a href="default/_mail_zde.html#functiontransmit3_addbox">transmit3_addbox()</a> in mail.zde</div>
 					</dd>
 		</dl>
 	<a name="u"></a>
@@ -1341,7 +1341,7 @@
 			<span class="method-title">updredir</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_game_htn.html#functionupdredir">updredir()</a> in game.htn</div>
+			<div class="index-item-details"><a href="default/_game_zde.html#functionupdredir">updredir()</a> in game.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Constant.png" alt="Constant" title="Constant" /></title>
@@ -1352,17 +1352,17 @@
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">user.htn</span>
+			<span class="include-title">user.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_user_htn.html">user.htn</a> in user.htn</div>
+			<div class="index-item-details"><a href="default/_user_zde.html">user.zde</a> in user.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Page.png" alt="Page" title="Page" /></title>
-			<span class="include-title">usrimg.htn</span>
+			<span class="include-title">usrimg.zde</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_usrimg_htn.html">usrimg.htn</a> in usrimg.htn</div>
+			<div class="index-item-details"><a href="default/_usrimg_zde.html">usrimg.zde</a> in usrimg.zde</div>
 					</dd>
 		</dl>
 	<a name="w"></a>
@@ -1406,7 +1406,7 @@
 			<span class="method-title">xpcinfo</span>
 					</dt>
 		<dd class="index-item-body">
-			<div class="index-item-details"><a href="default/_cluster_htn.html#functionxpcinfo">xpcinfo()</a> in cluster.htn</div>
+			<div class="index-item-details"><a href="default/_cluster_zde.html#functionxpcinfo">xpcinfo()</a> in cluster.zde</div>
 					</dd>
 			<dt class="field">
 						<img src="media/images/Function.png" alt="Function" title="Function" /></title>

--- a/doku/errors.html
+++ b/doku/errors.html
@@ -10,192 +10,192 @@
 		<body>
 						
 <a href="#Post-parsing">Post-parsing</a><br>
-<a href="#battle.htn">battle.htn</a><br>
+<a href="#battle.zde">battle.zde</a><br>
 <a href="#calc_points.php">calc_points.php</a><br>
-<a href="#cboard.htn">cboard.htn</a><br>
-<a href="#cluster.htn">cluster.htn</a><br>
+<a href="#cboard.zde">cboard.zde</a><br>
+<a href="#cluster.zde">cluster.zde</a><br>
 <a href="#config.php">config.php</a><br>
 <a href="#country_data.inc.php">country_data.inc.php</a><br>
 <a href="#derefer.php">derefer.php</a><br>
-<a href="#distrattack.htn">distrattack.htn</a><br>
-<a href="#game.htn">game.htn</a><br>
+<a href="#distrattack.zde">distrattack.zde</a><br>
+<a href="#game.zde">game.zde</a><br>
 <a href="#gres.php">gres.php</a><br>
 <a href="#impressum.php">impressum.php</a><br>
 <a href="#index.php">index.php</a><br>
 <a href="#ingame.php">ingame.php</a><br>
 <a href="#layout.php">layout.php</a><br>
-<a href="#login.htn">login.htn</a><br>
-<a href="#mail.htn">mail.htn</a><br>
-<a href="#pub.htn">pub.htn</a><br>
-<a href="#ranking.htn">ranking.htn</a><br>
-<a href="#search.htn">search.htn</a><br>
-<a href="#secret.htn">secret.htn</a><br>
+<a href="#login.zde">login.zde</a><br>
+<a href="#mail.zde">mail.zde</a><br>
+<a href="#pub.zde">pub.zde</a><br>
+<a href="#ranking.zde">ranking.zde</a><br>
+<a href="#search.zde">search.zde</a><br>
+<a href="#secret.zde">secret.zde</a><br>
 <a href="#selcountry.php">selcountry.php</a><br>
 <a href="#startseite.php">startseite.php</a><br>
-<a href="#user.htn">user.htn</a><br>
-<a href="#usrimg.htn">usrimg.htn</a><br>
+<a href="#user.zde">user.zde</a><br>
+<a href="#usrimg.zde">usrimg.zde</a><br>
 <a href="#worm.php">worm.php</a><br>
 <a name="Post-parsing"></a>
 <h1>Post-parsing</h1>
 <h2>Warnings:</h2><br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\login.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\login.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\user.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\user.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\mail.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\mail.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\pub.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\pub.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\game.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\game.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\distrattack.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\distrattack.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\static\selcountry.php will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\static\selcountry.php will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\secret.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\secret.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate function element "showform" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\search.htn will be ignored.
+duplicate function element "showform" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\search.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\battle.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\battle.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate function element "show_beitrag" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\secret.htn will be ignored.
+duplicate function element "show_beitrag" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\secret.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate function element "listboard" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\secret.htn will be ignored.
+duplicate function element "listboard" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\secret.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\search.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\search.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\ranking.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\ranking.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\cboard.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\cboard.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\cluster.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\cluster.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
 <b>Warning</b> - 
-duplicate define element "IN_HTN" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\usrimg.htn will be ignored.
+duplicate define element "IN_ZDE" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\usrimg.zde will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
-<a name="abook.htn"></a>
-<h1>abook.htn</h1>
+<a name="abook.zde"></a>
+<h1>abook.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 178</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\abook.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="battle.htn"></a>
-<h1>battle.htn</h1>
+<b>Warning on line 178</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\abook.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="battle.zde"></a>
+<h1>battle.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 842</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\battle.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 842</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\battle.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="calc_points.php"></a>
 <h1>calc_points.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 151</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\calc_points.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="cboard.htn"></a>
-<h1>cboard.htn</h1>
+<b>Warning on line 151</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\calc_points.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="cboard.zde"></a>
+<h1>cboard.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 298</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\cboard.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="cluster.htn"></a>
-<h1>cluster.htn</h1>
+<b>Warning on line 298</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\cboard.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="cluster.zde"></a>
+<h1>cluster.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 977</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\cluster.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 977</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\cluster.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="config.php"></a>
 <h1>config.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 35</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\config.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 35</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\config.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="country_data.inc.php"></a>
 <h1>country_data.inc.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 53</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\data\static\country_data.inc.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 53</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\data\static\country_data.inc.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="derefer.php"></a>
 <h1>derefer.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 9</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\derefer.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="distrattack.htn"></a>
-<h1>distrattack.htn</h1>
+<b>Warning on line 9</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\derefer.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="distrattack.zde"></a>
+<h1>distrattack.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 425</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\distrattack.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="game.htn"></a>
-<h1>game.htn</h1>
+<b>Warning on line 425</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\distrattack.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="game.zde"></a>
+<h1>game.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 907</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\game.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 907</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\game.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="gres.php"></a>
 <h1>gres.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 745</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\gres.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 745</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\gres.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="impressum.php"></a>
 <h1>impressum.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 12</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\data\pubtxt\impressum.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 12</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\data\pubtxt\impressum.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="index.php"></a>
 <h1>index.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 2</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\index.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 2</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\index.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="ingame.php"></a>
 <h1>ingame.php</h1>
 <h2>Warnings:</h2><br>
 <b>Warning on line 103</b> - 
-duplicate define element "UPGRADE_QUEUE_LENGTH" in file F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\ingame.php will be ignored.
+duplicate define element "UPGRADE_QUEUE_LENGTH" in file F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\ingame.php will be ignored.
 Use an @ignore tag on the original if you want this case to be documented.<br>
-<b>Warning on line 423</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\ingame.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 423</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\ingame.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="layout.php"></a>
 <h1>layout.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 136</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\layout.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="login.htn"></a>
-<h1>login.htn</h1>
+<b>Warning on line 136</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\layout.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="login.zde"></a>
+<h1>login.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 153</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\login.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="mail.htn"></a>
-<h1>mail.htn</h1>
+<b>Warning on line 153</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\login.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="mail.zde"></a>
+<h1>mail.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 510</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\mail.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="pub.htn"></a>
-<h1>pub.htn</h1>
+<b>Warning on line 510</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\mail.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="pub.zde"></a>
+<h1>pub.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 388</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\pub.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="ranking.htn"></a>
-<h1>ranking.htn</h1>
+<b>Warning on line 388</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\pub.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="ranking.zde"></a>
+<h1>ranking.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 206</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\ranking.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="search.htn"></a>
-<h1>search.htn</h1>
+<b>Warning on line 206</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\ranking.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="search.zde"></a>
+<h1>search.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 38</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\search.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="secret.htn"></a>
-<h1>secret.htn</h1>
+<b>Warning on line 38</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\search.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="secret.zde"></a>
+<h1>secret.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 315</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\secret.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 315</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\secret.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="selcountry.php"></a>
 <h1>selcountry.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 26</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\static\selcountry.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 26</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\static\selcountry.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="startseite.php"></a>
 <h1>startseite.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 33</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\data\pubtxt\startseite.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="user.htn"></a>
-<h1>user.htn</h1>
+<b>Warning on line 33</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\data\pubtxt\startseite.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="user.zde"></a>
+<h1>user.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 380</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\user.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
-<a name="usrimg.htn"></a>
-<h1>usrimg.htn</h1>
+<b>Warning on line 380</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\user.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<a name="usrimg.zde"></a>
+<h1>usrimg.zde</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 61</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\usrimg.htn" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 61</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\usrimg.zde" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 <a name="worm.php"></a>
 <h1>worm.php</h1>
 <h2>Warnings:</h2><br>
-<b>Warning on line 58</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\htn2\worm.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
+<b>Warning on line 58</b> - File "F:\Dateien von Ingmar\Meine Webseiten\Website\zde2\worm.php" has no page-level DocBlock, use @package in the first DocBlock to create one<br>
 	<p class="notes" id="credit">
 		Documentation generated on Sat,  4 Sep 2004 22:10:56 +0200 by <a href="http://www.phpdoc.org" target="_blank">phpDocumentor 1.3.0RC3</a>
 	</p>

--- a/doku/li_default.html
+++ b/doku/li_default.html
@@ -25,28 +25,28 @@
 																	<dt class="folder-title"><img class="tree-icon" src="media/images/function_folder.png" alt=" ">Functions</dt>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionaddpc' target='right'>addpc</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionAddSysMsg' target='right'>AddSysMsg</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_htn.html#functionaddtoattacklist' target='right'>addtoattacklist</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_abook_htn.html#functionadmin_list' target='right'>admin_list</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_zde.html#functionaddtoattacklist' target='right'>addtoattacklist</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_abook_zde.html#functionadmin_list' target='right'>admin_list</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionbadsession' target='right'>badsession</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_layout_php.html#functionbasicfooter' target='right'>basicfooter</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_layout_php.html#functionbasicheader' target='right'>basicheader</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_htn.html#functionbattle_table' target='right'>battle_table</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_htn.html#functionbr' target='right'>br</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_htn.html#functionbuildinfo' target='right'>buildinfo</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_zde.html#functionbattle_table' target='right'>battle_table</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_zde.html#functionbr' target='right'>br</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_zde.html#functionbuildinfo' target='right'>buildinfo</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functioncalc_mph' target='right'>calc_mph</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functioncalc_time' target='right'>calc_time</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_pub_htn.html#functionchecknick' target='right'>checknick</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_pub_zde.html#functionchecknick' target='right'>checknick</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functioncheck_email' target='right'>check_email</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functioncleardir' target='right'>cleardir</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_htn.html#functionconventlist' target='right'>conventlist</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_zde.html#functionconventlist' target='right'>conventlist</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_layout_php.html#functioncreatelayout_bottom' target='right'>createlayout_bottom</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_layout_php.html#functioncreatelayout_top' target='right'>createlayout_top</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functioncreate_sid' target='right'>create_sid</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functioncscodetostring' target='right'>cscodetostring</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_htn.html#functioncvCodeToString' target='right'>cvCodeToString</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_zde.html#functioncvCodeToString' target='right'>cvCodeToString</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functiondbname' target='right'>dbname</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functiondb_query' target='right'>db_query</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_htn.html#functiondeactivate' target='right'>deactivate</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_zde.html#functiondeactivate' target='right'>deactivate</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functiondeletecluster' target='right'>deletecluster</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functiondelete_account' target='right'>delete_account</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functiondereferurl' target='right'>dereferurl</a></dd>
@@ -54,14 +54,14 @@
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionfile_get' target='right'>file_get</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionfile_put' target='right'>file_put</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionformatitemlevel' target='right'>formatitemlevel</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_htn.html#functionformatText' target='right'>formatText</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_zde.html#functionformatText' target='right'>formatText</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionformat_cluster_code' target='right'>format_cluster_code</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_pub_htn.html#functiongenerateMnemonicPassword' target='right'>generateMnemonicPassword</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_htn.html#functiongetAttack' target='right'>getAttack</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_htn.html#functiongetcheckedmail_str' target='right'>getcheckedmail_str</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_pub_zde.html#functiongenerateMnemonicPassword' target='right'>generateMnemonicPassword</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_zde.html#functiongetAttack' target='right'>getAttack</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_zde.html#functiongetcheckedmail_str' target='right'>getcheckedmail_str</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionGetCluster' target='right'>GetCluster</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionGetCountry' target='right'>GetCountry</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_htn.html#functiongetDefend' target='right'>getDefend</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_zde.html#functiongetDefend' target='right'>getDefend</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functiongetfilecount' target='right'>getfilecount</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionGetIP' target='right'>GetIP</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functiongetiteminfo' target='right'>getiteminfo</a></dd>
@@ -74,15 +74,15 @@
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionGetOnlineUserCnt' target='right'>GetOnlineUserCnt</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionGetPC' target='right'>GetPC</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functiongetPCPoints' target='right'>getPCPoints</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_htn.html#functiongetsuccess' target='right'>getsuccess</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_zde.html#functiongetsuccess' target='right'>getsuccess</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionGetTableInfo' target='right'>GetTableInfo</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionGetUser' target='right'>GetUser</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionget_gdph' target='right'>get_gdph</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functiongFormatText' target='right'>gFormatText</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionhtml_entity_decode' target='right'>html_entity_decode</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionIDToName' target='right'>IDToName</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_secret_htn.html#functionidtotext' target='right'>idtotext</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_htn.html#functioninfobox' target='right'>infobox</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_secret_zde.html#functionidtotext' target='right'>idtotext</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_zde.html#functioninfobox' target='right'>infobox</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionisattackallowed' target='right'>isattackallowed</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionisavailb' target='right'>isavailb</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionisavailh' target='right'>isavailh</a></dd>
@@ -91,21 +91,21 @@
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionitemmaxval' target='right'>itemmaxval</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionitemnextlevel' target='right'>itemnextlevel</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionjoinex' target='right'>joinex</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_htn.html#functionlistboard' target='right'>listboard</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_abook_htn.html#functionlist_items' target='right'>list_items</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_htn.html#functionLoadSmilies' target='right'>LoadSmilies</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_htn.html#functionmaillist' target='right'>maillist</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_htn.html#functionmail_format_text' target='right'>mail_format_text</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_zde.html#functionlistboard' target='right'>listboard</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_abook_zde.html#functionlist_items' target='right'>list_items</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_zde.html#functionLoadSmilies' target='right'>LoadSmilies</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_zde.html#functionmaillist' target='right'>maillist</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_zde.html#functionmail_format_text' target='right'>mail_format_text</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_layout_php.html#functionmenu_entry' target='right'>menu_entry</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_htn.html#functionmmitem' target='right'>mmitem</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_htn.html#functionnewmailcount' target='right'>newmailcount</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_htn.html#functionnewmailform' target='right'>newmailform</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_zde.html#functionmmitem' target='right'>mmitem</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_zde.html#functionnewmailcount' target='right'>newmailcount</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_zde.html#functionnewmailform' target='right'>newmailform</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionNiceTime' target='right'>NiceTime</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionNiceTime2' target='right'>NiceTime2</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionNiceTime3' target='right'>NiceTime3</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionNiceTime4' target='right'>NiceTime4</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionNiceTime_GetStr' target='right'>NiceTime_GetStr</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_htn.html#functionnocluster' target='right'>nocluster</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_zde.html#functionnocluster' target='right'>nocluster</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionno_' target='right'>no_</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionprocessupgrades' target='right'>processupgrades</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionrandomchar' target='right'>randomchar</a></dd>
@@ -117,56 +117,56 @@
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionrem_e_callback' target='right'>rem_e_callback</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionsafeentities' target='right'>safeentities</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionSaveCluster' target='right'>SaveCluster</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_htn.html#functionsavemycluster' target='right'>savemycluster</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_zde.html#functionsavemycluster' target='right'>savemycluster</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionSavePC' target='right'>SavePC</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionSaveUser' target='right'>SaveUser</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionSaveUserData' target='right'>SaveUserData</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_calc_points_php.html#functionserver_update_points' target='right'>server_update_points</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionSetUserVal' target='right'>SetUserVal</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_pub_htn.html#functionshowdoc' target='right'>showdoc</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_htn.html#functionshowform' target='right'>showform</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_htn.html#functionshowinfo' target='right'>showinfo</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_htn.html#functionshow_beitrag' target='right'>show_beitrag</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_pub_zde.html#functionshowdoc' target='right'>showdoc</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_zde.html#functionshowform' target='right'>showform</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_zde.html#functionshowinfo' target='right'>showinfo</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cboard_zde.html#functionshow_beitrag' target='right'>show_beitrag</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionsimple_message' target='right'>simple_message</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_htn.html#functionsmash' target='right'>smash</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_pub_htn.html#functionstats' target='right'>stats</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_htn.html#functionstat_list_item' target='right'>stat_list_item</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_battle_zde.html#functionsmash' target='right'>smash</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_pub_zde.html#functionstats' target='right'>stats</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_zde.html#functionstat_list_item' target='right'>stat_list_item</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionSubnetFromIP' target='right'>SubnetFromIP</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functiontIsAvail' target='right'>tIsAvail</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_htn.html#functiontransmit2_mail_list' target='right'>transmit2_mail_list</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_htn.html#functiontransmit3_addbox' target='right'>transmit3_addbox</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_zde.html#functiontransmit2_mail_list' target='right'>transmit2_mail_list</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_mail_zde.html#functiontransmit3_addbox' target='right'>transmit3_addbox</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionunformat_cluster_code' target='right'>unformat_cluster_code</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_htn.html#functionupdredir' target='right'>updredir</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_game_zde.html#functionupdredir' target='right'>updredir</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_ingame_php.html#functionwrite_pc_list' target='right'>write_pc_list</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionwrite_session_data' target='right'>write_session_data</a></dd>
-											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_htn.html#functionxpcinfo' target='right'>xpcinfo</a></dd>
+											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_cluster_zde.html#functionxpcinfo' target='right'>xpcinfo</a></dd>
 											<dd><img class="tree-icon" src="media/images/Function.png" alt="Function"><a href='default/_gres_php.html#functionxpoint' target='right'>xpoint</a></dd>
 																		<dt class="folder-title"><img class="tree-icon" src="media/images/folder.png" alt=" ">Files</dt>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_abook_htn.html' target='right'>abook.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_battle_htn.html' target='right'>battle.htn</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_abook_zde.html' target='right'>abook.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_battle_zde.html' target='right'>battle.zde</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_calc_points_php.html' target='right'>calc_points.php</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_cboard_htn.html' target='right'>cboard.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_cluster_htn.html' target='right'>cluster.htn</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_cboard_zde.html' target='right'>cboard.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_cluster_zde.html' target='right'>cluster.zde</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_config_php.html' target='right'>config.php</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_data_static_country_data_inc_php.html' target='right'>country_data.inc.php</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_derefer_php.html' target='right'>derefer.php</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_distrattack_htn.html' target='right'>distrattack.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_game_htn.html' target='right'>game.htn</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_distrattack_zde.html' target='right'>distrattack.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_game_zde.html' target='right'>game.zde</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_gres_php.html' target='right'>gres.php</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_data_pubtxt_impressum_php.html' target='right'>impressum.php</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_index_php.html' target='right'>index.php</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_ingame_php.html' target='right'>ingame.php</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_layout_php.html' target='right'>layout.php</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_login_htn.html' target='right'>login.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_mail_htn.html' target='right'>mail.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_pub_htn.html' target='right'>pub.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_ranking_htn.html' target='right'>ranking.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_search_htn.html' target='right'>search.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_secret_htn.html' target='right'>secret.htn</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_login_zde.html' target='right'>login.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_mail_zde.html' target='right'>mail.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_pub_zde.html' target='right'>pub.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_ranking_zde.html' target='right'>ranking.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_search_zde.html' target='right'>search.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_secret_zde.html' target='right'>secret.zde</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_static_selcountry_php.html' target='right'>selcountry.php</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_data_pubtxt_startseite_php.html' target='right'>startseite.php</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_user_htn.html' target='right'>user.htn</a></dd>
-											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_usrimg_htn.html' target='right'>usrimg.htn</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_user_zde.html' target='right'>user.zde</a></dd>
+											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_usrimg_zde.html' target='right'>usrimg.zde</a></dd>
 											<dd><img class="tree-icon" src="media/images/Page.png" alt="File"><a href='default/_worm_php.html' target='right'>worm.php</a></dd>
 																	
 						

--- a/game.php
+++ b/game.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = true;
 include('ingame.php');
 
@@ -58,7 +58,7 @@ switch ($action) {
 #$info.=infobox('<b>ACHTUNG:</b> Multis keine Chance! Wer mehrere Accounts besitzt, wird gnadenlos gel&ouml;scht.');
 
         $SALT = file_get('data/upgr_SALT.dat');
-        $idparam = preg_replace('([./])', '', crypt('HtNiTeM', $SALT));
+        $idparam = preg_replace('([./])', '', crypt('ZDEiTeM', $SALT));
         function overview_upgrade_link($id)
         {
             global $pc, $sid, $SALT, $idparam;
@@ -763,7 +763,7 @@ createlayout_bottom();
 
 #file_put('data/upgr_SALT.dat', randomx(6));
             $SALT = file_get('data/upgr_SALT.dat');
-            $idparam = preg_replace('([./])', '', crypt('HtNiTeM', $SALT));
+            $idparam = preg_replace('([./])', '', crypt('ZDEiTeM', $SALT));
 
             function buildinfo($id)
             {
@@ -851,7 +851,7 @@ createlayout_bottom();
         }
 
         $SALT = file_get('data/upgr_SALT.dat');
-        $idparam = preg_replace('([./])', '', crypt('HtNiTeM', $SALT));
+        $idparam = preg_replace('([./])', '', crypt('ZDEiTeM', $SALT));
 
         $id = $_REQUEST[$idparam];
         foreach ($items as $xx) {

--- a/gres.php
+++ b/gres.php
@@ -1,11 +1,11 @@
 <?php
 
-if (!defined('IN_HTN')) {
+if (!defined('IN_ZDE')) {
     die('Hacking attempt');
 }
 
 #if($_COOKIE['SSL']=='yes' && $_SERVER['HTTP_HOST']!='ssl-id1.de') {
-#  header('Location: http://ssl-id1.de/htn.ir0.de'.$_SERVER['REQUEST_URI']);
+#  header('Location: http://ssl-id1.de/zde.ir0.de'.$_SERVER['REQUEST_URI']);
 #}
 
 define('LF', "\n");
@@ -15,7 +15,7 @@ define('LF', "\n");
 if (file_exists('data/work.txt') == true || file_exists('data/mysql-backup.txt') == true) {
     $STYLESHEET = 'crystal';
     include_once('layout.php');
-    createlayout_top('HackTheNet - Serverarbeiten', true);
+    createlayout_top('ZeroDayEmpire - Serverarbeiten', true);
     echo '
 <div class="content" id="work">
 <h2>Serverarbeiten</h2>
@@ -23,7 +23,7 @@ if (file_exists('data/work.txt') == true || file_exists('data/mysql-backup.txt')
 <h3>Information</h3>
 <p>Im Moment wird am Server gearbeitet.<br />
 Bitte probiere es doch später noch einmal.<br />
-Du kannst auch so lange dem <a href="http://forum.hackthenet.org/">Forum</a> oder <br />dem <a href="http://www.ghettogame.net">Ghettogame</a> einen Besuch abstatten.</p>
+Du kannst auch so lange dem <a href="http://forum.ZeroDayEmpire.org/">Forum</a> oder <br />dem <a href="http://www.ghettogame.net">Ghettogame</a> einen Besuch abstatten.</p>
 </div>
 </div>
 ';
@@ -148,11 +148,11 @@ if (isset($_GET['error'])) {
 }
 
 $host = $_SERVER['HTTP_HOST'];
-#$localhost=$host=='localhost'||$host=='htn.lc' ? true : false;
+#$localhost=$host=='localhost'||$host=='zde.lc' ? true : false;
 $localhost = false;
-#if($host=='htnsrv.org') $localhost=false;
+#if($host=='zdesrv.org') $localhost=false;
 
-//die('Aus technischen Grnden ist HackTheNet nicht erreichbar.<br />Das Forum ist jedoch zum Glck weiter online unter <a href="http://forum.hackthenet.org/">http://forum.hackthenet.org/</a>.');
+//die('Aus technischen Grnden ist ZeroDayEmpire nicht erreichbar.<br />Das Forum ist jedoch zum Glck weiter online unter <a href="http://forum.ZeroDayEmpire.org/">http://forum.ZeroDayEmpire.org/</a>.');
 
 function dbname($srvid = -1)
 {
@@ -646,9 +646,9 @@ function simple_message($msg, $type = 'warning')
             $c = 'Hinweis';
         }
     }
-    createlayout_top('HackTheNet - Hinweis');
+    createlayout_top('ZeroDayEmpire - Hinweis');
     echo '<div class="content">';
-    echo '<h2>HackTheNet</h2>';
+    echo '<h2>ZeroDayEmpire</h2>';
     echo '<br /><br />';
     echo '<div class="'.$id.'"><h3>'.$c.'</h3><p>'.$msg.'</p></div>';
     createlayout_bottom();

--- a/ingame.php
+++ b/ingame.php
@@ -2,7 +2,7 @@
 
 $starttime = microtime();
 
-if (!defined('IN_HTN')) {
+if (!defined('IN_ZDE')) {
     die('Hacking attempt');
 }
 
@@ -75,7 +75,7 @@ if ($usr['sid'] != $sid) {
     badsession('Das ist nicht deine Session-ID');
 } elseif ($usr['sid_ip'] != $ip && $usr['sid_ip'] != 'noip') {
     /* falsche IP-Adresse */
-    setcookie('htnLoginData');
+    setcookie('zdeLoginData');
     badsession(
         'Deine IP ist nicht dieser Session-ID zugeordnet!<br />Benutz die \'erweitertes LogIn\'-Funktion auf der Startseite.'
     );

--- a/layout.php
+++ b/layout.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('IN_HTN')) {
+if (!defined('IN_ZDE')) {
     die('Hacking attempt');
 }
 

--- a/login.php
+++ b/login.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 include('gres.php');
 
 $ref = $_SERVER['HTTP_REFERER'] ?? '';
@@ -75,28 +75,28 @@ if ($action == 'login') {
     $cookie = false;
 
     if (
-        isset($_COOKIE['htnLoginData4']) &&
-        substr_count($_COOKIE['htnLoginData4'], '|') == 2 &&
+        isset($_COOKIE['zdeLoginData4']) &&
+        substr_count($_COOKIE['zdeLoginData4'], '|') == 2 &&
         (($_POST['save'] ?? '') == 'yes')
     ) {
-        list($serverdummy, $usrnamedummy, $pwd) = explode('|', $_COOKIE['htnLoginData4']);
+        list($serverdummy, $usrnamedummy, $pwd) = explode('|', $_COOKIE['zdeLoginData4']);
         $cookie = true;
     }
     if (($_POST['save'] ?? '') == 'yes') {
         if ($cookie == false) {
-            setcookie('htnLoginData4', $server.'|'.$usrname.'|'.md5($pwd), time() + 10 * 365 * 24 * 60 * 60);
+            setcookie('zdeLoginData4', $server.'|'.$usrname.'|'.md5($pwd), time() + 10 * 365 * 24 * 60 * 60);
         } else {
             #if()
             if ($usrnamedummy != $usrname || $postpwd != '[xpwd]') {
                 $pwd = md5($postpwd);
             }
             #echo $postpwd;
-            setcookie('htnLoginData4', $server.'|'.$usrname.'|'.$pwd, time() + 10 * 365 * 24 * 60 * 60);
+            setcookie('zdeLoginData4', $server.'|'.$usrname.'|'.$pwd, time() + 10 * 365 * 24 * 60 * 60);
             #echo $server.'|'.$usrname.'|'.$pwd;
             $cookie = true;
         }
     } else {
-        setcookie('htnLoginData4');
+        setcookie('zdeLoginData4');
     }
 
     mysql_select_db(dbname($server));
@@ -139,7 +139,7 @@ if ($action == 'login') {
 <h1>Account gesperrt!</h1>
 <b>Dieser Account wurde durch den Administrator des Spiels gesperrt!!</b>
 <br /><br />Das kann z.B. geschehen sein, weil du ein Multi bist.<br />Bei Fragen, Beschwerden und wenn
-du die genauen Gr&uuml;nde wissen willst, schick eine Email an <a href="mailto:king@hackthenet.org">king@hackthenet.org</a>!
+du die genauen Gr&uuml;nde wissen willst, schick eine Email an <a href="mailto:king@ZeroDayEmpire.org">king@ZeroDayEmpire.org</a>!
 </body></html>';
                 exit;
             }
@@ -212,7 +212,7 @@ du die genauen Gr&uuml;nde wissen willst, schick eine Email an <a href="mailto:k
         unlink('data/login/'.$sid.'.txt');
     }
     if (($_GET['redir'] ?? '') == 'forum') {
-        header('Location: http://forum.hackthenet.org/');
+        header('Location: http://forum.ZeroDayEmpire.org/');
     } else {
         header('Location: index.php');
     }

--- a/mail.php
+++ b/mail.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = false;
 include('ingame.php');
 
@@ -716,7 +716,7 @@ createlayout_bottom();
 
         $text = '|'.str_replace(LF, LF.'|', wordwrap($text, 50, LF));
 
-        createlayout_top('HackTheNet - Messages');
+        createlayout_top('ZeroDayEmpire - Messages');
 ?>
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
@@ -741,7 +741,7 @@ createlayout_bottom();
         break;
 
     case 'transmit1': //------------------------- TRANSMIT 1 -------------------------------
-        createlayout_top('HackTheNet - Messages - Mails übertragen');
+        createlayout_top('ZeroDayEmpire - Messages - Mails übertragen');
 ?>
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
@@ -753,7 +753,7 @@ createlayout_bottom();
 <h2>Messages</h2>
 <div id="messages-transmit1">
 <h3>Mails &uuml;bertragen</h3>
-<p>Mit dieser Funktion kannst du ausgew&auml;hlte HTN-Ingame-Nachrichten zur Archivierung oder,
+<p>Mit dieser Funktion kannst du ausgew&auml;hlte ZDE-Ingame-Nachrichten zur Archivierung oder,
 um Platz im Postfach zu schaffen,
 an deine Email-Adresse schicken.<br />
 Du erh&auml;ltst dann eine Email, in deren Anhang du alle gew&auml;hlten Ingame-Messages als Textdateien findest.</p>
@@ -765,7 +765,7 @@ Du erh&auml;ltst dann eine Email, in deren Anhang du alle gew&auml;hlten Ingame-
 </tr>
 <tr id="messages-transmit1-mail-subject">
 <th>Email-Betreff:</th>
-<td><input type="text" value="HackTheNet-Ingame-Mails" name="subject" /></td>
+<td><input type="text" value="ZeroDayEmpire-Ingame-Mails" name="subject" /></td>
 </tr>
 <tr><th>Ordner:</th>
 <td><input type="checkbox" name="in" value="yes" checked="checked" /> Nachrichten-Eingang<br />
@@ -788,7 +788,7 @@ createlayout_bottom();
         break;
 
     case 'transmit2': //------------------------- TRANSMIT 2 -------------------------------
-        createlayout_top('HackTheNet - Messages - Mails übertragen');
+        createlayout_top('ZeroDayEmpire - Messages - Mails übertragen');
 ?>
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>
@@ -950,7 +950,7 @@ createlayout_bottom();
             }
         }
 
-        $bound = 'BOUND_'.randomx(5).'_HTN';
+        $bound = 'BOUND_'.randomx(5).'_ZDE';
 #$bound='BOUND';
 
         $body = '';
@@ -966,22 +966,22 @@ createlayout_bottom();
         }
 
         $msg = nicetime(
-            ).LF.'http://www.hackthenet.org/'.LF."\n".'Hallo '.$usr['name'].'!'.LF.'Hier kommen deine HackTheNet-Ingame-Messages!'.LF."\n"
+            ).LF.'http://www.ZeroDayEmpire.org/'.LF."\n".'Hallo '.$usr['name'].'!'.LF.'Hier kommen deine ZeroDayEmpire-Ingame-Messages!'.LF."\n"
             .'Es sind insgesamt '.count(
                 $list
             ).' Nachrichten, die jeweils als Textdatei an diese Mail angehangen wurden:'."\n";
         foreach ($list As $mail) {
             $msg .= '    » '.$mail."\n";
         }
-        $msg .= "\n".LF.'Greetz'.LF.'HackTheNet-Team';
-        $header = 'From: HackTheNet-Mail-Robot <robot@hackthenet.org>'.LF.'To: '.$usr['name'].' <'.$email.'>'.LF.'X-Mailer: HackTheNet-Mail-Robot by IR'.LF.'MIME-Version: 1.0'.LF.'Content-Type: multipart/mixed; boundary="'.$bound.'"';
+        $msg .= "\n".LF.'Greetz'.LF.'ZeroDayEmpire-Team';
+        $header = 'From: ZeroDayEmpire-Mail-Robot <robot@ZeroDayEmpire.org>'.LF.'To: '.$usr['name'].' <'.$email.'>'.LF.'X-Mailer: ZeroDayEmpire-Mail-Robot by IR'.LF.'MIME-Version: 1.0'.LF.'Content-Type: multipart/mixed; boundary="'.$bound.'"';
 
         $body = '--'.$bound."\n".'Content-Type: text/plain; charset="ISO-8859-1"'."\n"
             .'Content-Disposition: inline'."\n"
             .'Content-Transfer-Encoding: 8bit'."\n"
             .LF.$msg."\n".$body;
 
-        createlayout_top('HackTheNet - Messages');
+        createlayout_top('ZeroDayEmpire - Messages');
 ?>
 <!-- ZDE theme inject -->
 <style>@import url("style.css");</style>

--- a/pub.php
+++ b/pub.php
@@ -1,8 +1,8 @@
 <?php
 
-#if(substr_count($_SERVER['HTTP_HOST'],'.')>1) { header('Location: http://htnsrv.org/pub.php'); exit; }
+#if(substr_count($_SERVER['HTTP_HOST'],'.')>1) { header('Location: http://zdesrv.org/pub.php'); exit; }
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $starttime = microtime();
 include('gres.php');
 include('layout.php');
@@ -140,7 +140,7 @@ createlayout_bottom();
                 'regelverstoss@local.host',
                 'Regelversto&szlig; gemeldet von '.$nick1,
                 $nick2.' hat angeblich folgendes getan:'.LF."\n".$text,
-                'From: HackTheNet <robot@hackthenet.org>'
+                'From: ZeroDayEmpire <robot@ZeroDayEmpire.org>'
             );
             echo '<div class="ok"><h3>Gemeldet.</h3><p>Danke f&uuml;r deine Hilfe!</p></div>';
         } else {
@@ -340,7 +340,7 @@ createlayout_bottom();
             exit;
         }
 
-        $body = 'Hallo '.$nick.'!'.LF."\n".'Du hast dich bei HackTheNet (http://www.hackthenet.org) angemeldet!';
+        $body = 'Hallo '.$nick.'!'.LF."\n".'Du hast dich bei ZeroDayEmpire (http://www.ZeroDayEmpire.org) angemeldet!';
         $body .= ' Hier sind deine Zugangsdaten!'.LF."\n".'Server: Server '.$server."\n".'Nickname: '.$nick."\n".'Passwort: '.$pwd."\n"."\n".'Bevor du deinen';
         $body .= ' neuen Account nutzen kannst, musst du ihn aktivieren! Rufe dazu die folgende URL in deinem Browser auf:'.LF."\n";
         /*if($localhost)*/
@@ -351,7 +351,7 @@ createlayout_bottom();
         $body .= "\n";
 
         /*
-        if(@mail($email,'Dein HackTheNet Account',$body,'From: HackTheNet <robot@hackthenet.org>')) {
+        if(@mail($email,'Dein ZeroDayEmpire Account',$body,'From: ZeroDayEmpire <robot@ZeroDayEmpire.org>')) {
           readfile('data/pubtxt/regok.txt');
         } else {
         if($localhost)*/
@@ -499,9 +499,9 @@ createlayout_bottom();
 
                     if (@mail(
                         $email,
-                        'Zugangsdaten für HackTheNet',
-                        "\n".'http://www.hackthenet.org/'.LF."\n".'Server: Server '.$server."\n".'Benutzername: '.$usr['name'].LF.'Passwort: '.$pwd."\n",
-                        'From: HackTheNet <robot@hackthenet.org>'
+                        'Zugangsdaten für ZeroDayEmpire',
+                        "\n".'http://www.ZeroDayEmpire.org/'.LF."\n".'Server: Server '.$server."\n".'Benutzername: '.$usr['name'].LF.'Passwort: '.$pwd."\n",
+                        'From: ZeroDayEmpire <robot@ZeroDayEmpire.org>'
                     )
                     ) {
                         db_query('UPDATE users SET sid=\'\' WHERE id=\''.mysql_escape_string($usr['id']).'\' LIMIT 1;');

--- a/ranking.php
+++ b/ranking.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = false;
 include('ingame.php');
 

--- a/run_calc_points.php
+++ b/run_calc_points.php
@@ -1,7 +1,7 @@
 <?php
 // Wrapper script to run point calculation from CLI.
-// Defines IN_HTN constant and includes calc_points.php
+// Defines IN_ZDE constant and includes calc_points.php
 // to allow execution without direct web access.
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 require __DIR__ . '/calc_points.php';

--- a/search.php
+++ b/search.php
@@ -2,7 +2,7 @@
 
 // nie fertig geworden!
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = false;
 include('ingame.php');
 
@@ -24,7 +24,7 @@ function showform()
 {
     global $sid;
     echo '<div id="search-form">
-<h3>HackTheNet-Suche</h3>
+<h3>ZeroDayEmpire-Suche</h3>
 <!--
 <h4>Listen</h4>
 <p>
@@ -178,7 +178,7 @@ pan.style.display=\'block\';
 }
 </script>
 ';
-        createlayout_top('HackTheNet - Suche');
+        createlayout_top('ZeroDayEmpire - Suche');
         echo '<div class="content" id="search">'."\n";
         echo '<h2>Suche</h2>'."\n";
         showform();

--- a/secret.php
+++ b/secret.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = false;
 include('ingame.php');
 
@@ -38,7 +38,7 @@ switch ($action) {
                 break;
         }
 
-        $title = 'htn_server'.$server.'.'.$_REQUEST['type'].'s.'.$dat['id'];
+        $title = 'zde_server'.$server.'.'.$_REQUEST['type'].'s.'.$dat['id'];
 
         if ($usr['stat'] == 1000) {
             $hw = 'Du bist Administrator und darfst alles ansehen und &auml;ndern!';
@@ -162,7 +162,7 @@ alert(\'Bitte Zahl eingeben!\');
             exit;
         }
 
-        createlayout_top('HackTheNet - FREMDES Board');
+        createlayout_top('ZeroDayEmpire - FREMDES Board');
         echo '<div id="cluster-board" class="content">';
         echo '<h2>FREMDES Board</h2>';
 
@@ -350,13 +350,13 @@ alert(\'Bitte Zahl eingeben!\');
 
 
         while ($data = mysql_fetch_assoc($r)):
-            /*mail($data['email'], 'Dein HackTheNet-Account wird bald gelöscht!',
+            /*mail($data['email'], 'Dein ZeroDayEmpire-Account wird bald gelöscht!',
             'Hallo '.$data['name'].'!'.LF.'Du hast dich in deinen Account des browserbasierten Online-Spiels '.
-            'HackTheNet ( http://www.hackthenet.org/ ) seit '.nicetime($data['login_time']).' nicht mehr '.
+            'ZeroDayEmpire ( http://www.ZeroDayEmpire.org/ ) seit '.nicetime($data['login_time']).' nicht mehr '.
             'eingeloggt.'.LF.'Wenn du dich nicht bis zum 3. Juli, 24 Uhr mit den folgenden Daten einloggst, '.
             'wird dein Account automatisch gelöscht!'.LF."\n".'Nickname: '.$data['name'].LF.'Passwort: '.$data['password'].LF.'Server: 1'.LF."\n".
-            'MfG'.LF.'Das HackTheNet-Team',
-            'From: HackTheNet <robot@hackthenet.org>');*/
+            'MfG'.LF.'Das ZeroDayEmpire-Team',
+            'From: ZeroDayEmpire <robot@ZeroDayEmpire.org>');*/
             #delete_account($data['id']);
         endwhile;
 

--- a/static/selcountry.php
+++ b/static/selcountry.php
@@ -19,7 +19,7 @@
 <body style="font-family:arial;">
 
 <?php
-define("IN_HTN", 1);
+define("IN_ZDE", 1);
 include("../gres.php");
 echo str_replace("%path%", "../images/maps", file_get("../data/pubtxt/selcountry_body.txt"));
 ?>

--- a/user.php
+++ b/user.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = false;
 include('ingame.php');
 
@@ -153,7 +153,7 @@ switch ($action) {
                 strlen($dirname) - 1,
                 1
             ) != '/' ? $dirname.'/' : $dirname);
-            $url = 'http://htnsrv.org/usrimg.php/'.$server.'-'.$usrid.'.png';
+            $url = 'http://zdesrv.org/usrimg.php/'.$server.'-'.$usrid.'.png';
             $usrimg = ($usr['enable_usrimg'] != 'yes' ? '' : 'checked="checked" ');
             $usrimg = '<input type="checkbox" value="yes" name="enable_usrimg" '.$usrimg.'/>
  URL des Bildes: <a href="'.$url.'">'.$url.'</a>';
@@ -328,13 +328,13 @@ createlayout_bottom();
 </body></html>';
             $code = randomx(16);
 
-            $body = 'Hallo '.$usr['name'].'!'.LF."\n".'Schade, dass du deinen Account bei www.hackthenet.org löschen möchtest!'.LF."\n";
+            $body = 'Hallo '.$usr['name'].'!'.LF."\n".'Schade, dass du deinen Account bei www.ZeroDayEmpire.org löschen möchtest!'.LF."\n";
             $body .= 'Wenn du dir ganz sicher bist, klicke auf den folgenden Link:'."\n";
             $body .= 'http://'.$_SERVER['HTTP_HOST'].dirname(
                     $_SERVER['PHP_SELF']
                 ).'/pub.php?a=deleteaccount&code='.$code;
 
-            if (!@mail($usr['email'], 'ZeroDayEmpire-Account löschen?', $body, 'From: robot@hackthenet.org')) {
+            if (!@mail($usr['email'], 'ZeroDayEmpire-Account löschen?', $body, 'From: robot@ZeroDayEmpire.org')) {
                 echo nl2br($body);
             }
 

--- a/usrimg.php
+++ b/usrimg.php
@@ -1,6 +1,6 @@
 <?php
 
-define('IN_HTN', 1);
+define('IN_ZDE', 1);
 include 'gres.php';
 include 'layout.php';
 
@@ -54,7 +54,7 @@ if (file_exists($imgfile) != true) {
     $black = imagecolorallocate($hImg, 0, 0, 0);
     imagerectangle($hImg, 0, 0, $w - 1, $h - 1, $black);
     $darkred = imagecolorallocate($hImg, 128, 0, 0);
-    imagestringup($hImg, 5, 1, $h - 6, 'HTN', $darkred);
+    imagestringup($hImg, 5, 1, $h - 6, 'ZDE', $darkred);
     imagestring($hImg, 3, 20, 2, $usr['name'], $black);
     imagestring($hImg, 1, 20, 15, 'Server '.$server, $black);
     $currenty = 24;

--- a/worm.php
+++ b/worm.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!defined('IN_HTN')) {
+if (!defined('IN_ZDE')) {
     die('Hacking attempt');
 }
 


### PR DESCRIPTION
## Summary
- Replace all remaining HackTheNet and HTN references with ZeroDayEmpire or ZDE.
- Update configuration and documentation to use ZDE naming and domains.

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 -P8 php -l`


------
https://chatgpt.com/codex/tasks/task_b_689f1bd2453c8325a958026467c48ddd