### PR TITLE
Simplify public login and fix footer links

### DIFF
--- a/data/pubtxt/startseite.php
+++ b/data/pubtxt/startseite.php
@@ -23,40 +23,15 @@
                 </tr>
                 <tr>
                     <th>Passwort:</th>
-                    <td><input type="password" name="pwd" <?= $pwd ?>/></td>
-                </tr>
-                <tr>
-                    <td colspan="2"><a href="#public-login-extended-options">Erweiterte Optionen anzeigen &raquo;</a>
-                    </td>
-                </tr>
-                <tr id="public-login-extended-options">
-                    <th>Erweiterte Optionen:</th>
-                    <td><input type="checkbox" name="save" value="yes" <?= $sv ?>/> Login speichern<br/>
-                        <input type="checkbox" name="noipcheck" value="yes"/> IP-Überprüfung deaktivieren (nicht
-                        empfohlen)
+                    <td><input type="password" name="pwd" <?= $pwd ?>/><br/>
+                        <label><input type="checkbox" name="save" value="yes" <?= $sv ?>/> Login speichern</label>
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="2"><input type="hidden" name="server" value="1"/><input type="submit" value="Enter"/>
+                    <td colspan="2"><input type="hidden" name="server" value="1"/><input type="submit" value="Login"/>
                     </td>
                 </tr>
             </table>
         </form>
     </div>
-
-    <div id="public-statistic"><h3>Statistik</h3>
-        <p>
-            <?php
-            $gcnt = GetOnlineUserCnt(1);
-            echo "Spieler online: $gcnt<br />\n";
-            ?></p>
-        <p><a href="pub.php?d=stats">Ausführliche Statistik</a></p></div>
-
-    <div class="info"><h3>Aktuelle News</h3>
-        <p>Besuchen Sie auch das Original dieses Spiels auf <a href="http://www.ZeroDayEmpire.org/">www.ZeroDayEmpire.org</a>.
-        </p>
-        <p>Auf unseren Seiten sehen wir den Internet Explorer nicht so gerne, wir empfehlen statt dessen den <a
-                href="http://www.mozilla.org/products/firefox/">Firefox</a>.</p>
-        <p>Der offizielle ZDE-IRC-Channel ist im Freakarea-Netzwerk zu finden! Server ist <em>irc.freakarea.net</em>,
-            Channel <em>#ZeroDayEmpire</em>.
-    </div>
+</div>

--- a/layout.php
+++ b/layout.php
@@ -86,7 +86,7 @@ function createlayout_bottom()
     echo "</main>\n";
     echo '<footer><div class="container foot">';
     echo '<div>© <span id="year"></span> ZeroDayEmpire</div>';
-    echo '<div class="links"><a href="#">Status</a><a href="#">Roadmap</a><a href="impressum.html">Impressum</a></div>';
+    echo '<div class="links"><a href="impressum.php">Impressum</a><a href="legal.php">Legal</a></div>';
     echo '</div></footer>';
     echo '<script>(function(){const nav=document.getElementById("nav");const btn=document.getElementById("menuBtn");if(btn){btn.addEventListener("click",()=>{const open=nav.classList.toggle("open");btn.setAttribute("aria-expanded",String(open));});}})();';
     echo 'window.addEventListener("pointermove",e=>{const x=e.clientX/window.innerWidth*100;const y=e.clientY/window.innerHeight*100;document.documentElement.style.setProperty("--mx",x+"%");document.documentElement.style.setProperty("--my",y+"%");},{passive:true});';


### PR DESCRIPTION
## Summary
- Remove news, statistics, and extended options from public start page
- Place "Login speichern" below password field and rename submit button to "Login"
- Replace footer links with correctly linked Impressum and new Legal page

## Testing
- `php -l data/pubtxt/startseite.php`
- `php -l layout.php`


------
https://chatgpt.com/codex/tasks/task_b_68a062f209a48325b969a23417d665ec