### PR TITLE
Preserve login state across info pages and simplify navigation

### DIFF
--- a/impressum.php
+++ b/impressum.php
@@ -21,7 +21,6 @@
       <button class="btn ghost menu-toggle" id="menuBtn" aria-expanded="false" aria-controls="navList">Menü</button>
       <nav class="nav-links" id="navList" aria-label="Hauptnavigation">
         <a href="pub.php?a=register" id="registerLink">Registrieren</a>
-        <a href="pub.php" id="loginLink">Anmelden</a>
         <a href="dashboard.html" id="dashboardLink" style="display:none">Dashboard</a>
         <a href="#" id="logoutLink" style="display:none" onclick="logout()">Abmelden</a>
         <a href="config.html" id="configLink" style="display:none">Config</a>
@@ -49,10 +48,12 @@
   </footer>
   <script>
     (function(){
-      const token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
+      let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
+      if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
+        localStorage.setItem('token', token);
+      }
       const role = localStorage.getItem('role') || sessionStorage.getItem('role');
       const reg = document.getElementById('registerLink');
-      const login = document.getElementById('loginLink');
       const dash = document.getElementById('dashboardLink');
       const logout = document.getElementById('logoutLink');
       const cfg = document.getElementById('configLink');
@@ -68,7 +69,6 @@
       };
       if(token){
         if(reg) reg.style.display='none';
-        if(login) login.style.display='none';
         if(dash) dash.style.display='inline-flex';
         if(logout) logout.style.display='inline-flex';
         playLinks.forEach(a => a.href='dashboard.html');

--- a/index.php
+++ b/index.php
@@ -35,7 +35,6 @@ if ($row = mysql_fetch_assoc($r)) {
 
       <nav class="nav-links" id="navList" aria-label="Hauptnavigation">
         <a href="pub.php?a=register" id="registerLink">Registrieren</a>
-        <a href="pub.php" id="loginLink">Anmelden</a>
         <a href="dashboard.html" id="dashboardLink" style="display:none">Dashboard</a>
         <a href="#" id="logoutLink" style="display:none" onclick="logout()">Abmelden</a>
         <a href="config.html" id="configLink" style="display:none">Config</a>
@@ -114,37 +113,38 @@ if ($row = mysql_fetch_assoc($r)) {
 
   <script>
     // Anzeige basierend auf Login-Status und Rolle
-    (function(){
-      const token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
-      const role = localStorage.getItem('role') || sessionStorage.getItem('role');
-      const reg = document.getElementById('registerLink');
-      const login = document.getElementById('loginLink');
-      const dash = document.getElementById('dashboardLink');
-      const logout = document.getElementById('logoutLink');
-      const cfg = document.getElementById('configLink');
-      const playLinks = document.querySelectorAll('.play-link');
+      (function(){
+        let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
+        if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
+          localStorage.setItem('token', token);
+        }
+        const role = localStorage.getItem('role') || sessionStorage.getItem('role');
+        const reg = document.getElementById('registerLink');
+        const dash = document.getElementById('dashboardLink');
+        const logout = document.getElementById('logoutLink');
+        const cfg = document.getElementById('configLink');
+        const playLinks = document.querySelectorAll('.play-link');
 
-      window.logout = function(){
-        localStorage.removeItem('token');
-        localStorage.removeItem('role');
-        sessionStorage.removeItem('token');
-        sessionStorage.removeItem('role');
-        document.cookie = 'token=; Max-Age=0; path=/';
-        fetch('/logout',{method:'POST',headers:{'Authorization':token}});
-        window.location.href = 'index.php';
-      };
+        window.logout = function(){
+          localStorage.removeItem('token');
+          localStorage.removeItem('role');
+          sessionStorage.removeItem('token');
+          sessionStorage.removeItem('role');
+          document.cookie = 'token=; Max-Age=0; path=/';
+          fetch('/logout',{method:'POST',headers:{'Authorization':token}});
+          window.location.href = 'index.php';
+        };
 
-      if(token){
-        if(reg) reg.style.display='none';
-        if(login) login.style.display='none';
-        if(dash) dash.style.display='inline-flex';
-        if(logout) logout.style.display='inline-flex';
-        playLinks.forEach(a => a.href='dashboard.html');
-      }else{
-        playLinks.forEach(a => a.href='pub.php');
-      }
-      if(role === 'admin' && cfg){ cfg.style.display = 'inline-flex'; }
-    })();
+        if(token){
+          if(reg) reg.style.display='none';
+          if(dash) dash.style.display='inline-flex';
+          if(logout) logout.style.display='inline-flex';
+          playLinks.forEach(a => a.href='dashboard.html');
+        }else{
+          playLinks.forEach(a => a.href='pub.php');
+        }
+        if(role === 'admin' && cfg){ cfg.style.display = 'inline-flex'; }
+      })();
 
     // Mobile menu toggle
     (function(){

--- a/legal.php
+++ b/legal.php
@@ -21,7 +21,6 @@
       <button class="btn ghost menu-toggle" id="menuBtn" aria-expanded="false" aria-controls="navList">Menü</button>
       <nav class="nav-links" id="navList" aria-label="Hauptnavigation">
         <a href="pub.php?a=register" id="registerLink">Registrieren</a>
-        <a href="pub.php" id="loginLink">Anmelden</a>
         <a href="dashboard.html" id="dashboardLink" style="display:none">Dashboard</a>
         <a href="#" id="logoutLink" style="display:none" onclick="logout()">Abmelden</a>
         <a href="config.html" id="configLink" style="display:none">Config</a>
@@ -52,10 +51,12 @@
   </footer>
   <script>
     (function(){
-      const token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
+      let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
+      if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
+        localStorage.setItem('token', token);
+      }
       const role = localStorage.getItem('role') || sessionStorage.getItem('role');
       const reg = document.getElementById('registerLink');
-      const login = document.getElementById('loginLink');
       const dash = document.getElementById('dashboardLink');
       const logout = document.getElementById('logoutLink');
       const cfg = document.getElementById('configLink');
@@ -71,7 +72,6 @@
       };
       if(token){
         if(reg) reg.style.display='none';
-        if(login) login.style.display='none';
         if(dash) dash.style.display='inline-flex';
         if(logout) logout.style.display='inline-flex';
         playLinks.forEach(a => a.href='dashboard.html');


### PR DESCRIPTION
## Summary
- Remove redundant **Anmelden** link from header navigation on index, legal, and impressum pages
- Persist auth token across pages so dashboard/logout links remain visible until the user chooses **Abmelden**

## Testing
- `php -l index.php legal.php impressum.php`


------
https://chatgpt.com/codex/tasks/task_b_68a065ffbfe48325bc6eb2e8bb5f03d6