### PR TITLE
Decouple ranking page from point recalculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ Wenn mehrere Systemnutzer deployen, kannst du eine gemeinsame Gruppe verwenden u
 
 Rufe die Site im Browser auf. Initial stehen Test‑Accounts zur Verfügung (z. B. *Administrator*, *Administrator2*, *TestUser*). **Passwörter sind leer** – bitte sofort ändern bzw. Testnutzer deaktivieren.
 
+### 6. Cronjob für Punkteberechnung
+
+Die Rangliste wird nicht mehr durch das Aufrufen einer Webseite aktualisiert. Stattdessen muss regelmäßig ein Cronjob den Punkteberechnungsskript ausführen:
+
+```cron
+0 */3 * * * /bin/sh /pfad/zum/zde2/cron/run_calc_points.sh
+```
+
+Der obige Eintrag berechnet alle drei Stunden die Punkte neu. `run_calc_points.sh` ruft intern `run_calc_points.php` im CLI-Modus auf.
+
 ---
 
 ## 🔒 Sicherheitsempfehlungen

--- a/cron/run_calc_points.sh
+++ b/cron/run_calc_points.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Cron wrapper to update ranking points without web trigger
+# Usage: schedule via crontab, e.g. every 3 hours
+# 0 */3 * * * /bin/sh /path/to/cron/run_calc_points.sh
+php "$(dirname "$0")/../run_calc_points.php"

--- a/ranking.php
+++ b/ranking.php
@@ -39,12 +39,6 @@ switch ($action) {
 
 
         $next_update = (int)@file_get('data/calc-time.dat');
-        if ($next_update < time() && !file_exists('data/calc-running.dat')) {
-            ob_start();
-            include __DIR__ . '/calc_points.php';
-            ob_end_clean();
-            $next_update = (int)@file_get('data/calc-time.dat');
-        }
         $updtime = nicetime($next_update);
         echo '<div class="content" id="ranking">
 <h2>Rangliste</h2>


### PR DESCRIPTION
## Summary
- Stop ranking.php from triggering point recalculation on first visit
- Document dedicated cron job and add helper script to run point calculation periodically

## Testing
- `php -l ranking.php`
- `php -l run_calc_points.php`
- `bash -n cron/run_calc_points.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a097032c488325b054f04d99b55320