### PR TITLE
Load config in gres.php to avoid undefined variable warnings

### DIFF
--- a/gres.php
+++ b/gres.php
@@ -10,6 +10,8 @@ if (!defined('IN_ZDE')) {
 
 define('LF', "\n");
 
+include_once 'config.php';
+
 
 #if($_SERVER['REMOTE_ADDR']!='213.54.101.168') {
 if (file_exists('data/work.txt') == true || file_exists('data/mysql-backup.txt') == true) {


### PR DESCRIPTION
## Summary
- include `config.php` in `gres.php` so database and stylesheet config variables exist before use

## Testing
- `find . -path './doku' -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_b_68b0389778688325a9931b207ccd217b