### PR TITLE
fix: prevent cluster members warning

### DIFF
--- a/game.php
+++ b/game.php
@@ -248,7 +248,7 @@ switch ($action) {
       <ul class="muted" style="list-style:none; padding-left:0; margin:10px 0 0 0">
         <li><strong><?php echo safeentities($cluster['name']); ?></strong></li>
         <li>Punkte: <?php echo number_format($cluster['points'],0,',','.'); ?></li>
-        <li>Mitglieder: <?php echo $cluster['members']; ?></li>
+        <li>Mitglieder: <?php echo $cluster['members'] ?? 0; ?></li>
         <li>Geld: <?php echo number_format($cluster['money'],0,',','.'); ?> CR</li>
       </ul>
     <?php } else { ?>


### PR DESCRIPTION
## Summary
- avoid PHP warning by defaulting to zero when cluster member count is missing

## Testing
- `php -l game.php`


------
https://chatgpt.com/codex/tasks/task_b_68b03ba2702483258fe8dfff11c4b378