### PR TITLE
Ensure research info box renders

### DIFF
--- a/research.php
+++ b/research.php
@@ -42,6 +42,16 @@ echo '<div class="content" id="computer">'."\n";
 echo '<h2>Forschung</h2>'."\n";
 echo '<div class="submenu"><p><a href="game.php?m=start&amp;sid='.$sid.'">Zur &Uuml;bersicht</a></p></div>'."\n";
 
+if (!function_exists('infobox')) {
+    function infobox($titel, $class, $text, $param = 'class')
+    {
+        return "<div {$param}=\"{$class}\">\n"
+            . "<h3>{$titel}</h3>\n"
+            . "<p>{$text}</p>\n"
+            . "</div>\n";
+    }
+}
+
 include 'includes/codex_infobox_research.php';
 
 $notif = '';


### PR DESCRIPTION
## Summary
- Provide an `infobox` helper in `research.php` so the research page can render info boxes.

## Testing
- `php -l research.php`
- `php -l includes/codex_infobox_research.php`


------
https://chatgpt.com/codex/tasks/task_b_68b040c659a0832590b231869ea01cee