### PR TITLE
Improve research page labels and MySQL wrapper

### DIFF
--- a/gres.php
+++ b/gres.php
@@ -100,6 +100,12 @@ function mysql_insert_id()
     return mysqli_insert_id($dbcon);
 }
 
+function mysql_affected_rows()
+{
+    global $dbcon;
+    return mysqli_affected_rows($dbcon);
+}
+
 function mysql_data_seek($r, $offset)
 {
     return mysqli_data_seek($r, $offset);

--- a/includes/research.php
+++ b/includes/research.php
@@ -56,7 +56,7 @@ function research_check_deps($pcid,$track,$target_level)
         );
         $level = ($tmp = mysql_fetch_assoc($req)) ? (int)$tmp['level'] : 0;
         if ($level < (int)$dep['req_level']) {
-            return 'Ben&ouml;tigt '.$dep['req_track'].' Stufe '.$dep['req_level'];
+            return 'Benötigt '.$dep['req_track'].' Stufe '.$dep['req_level'];
         }
     }
     return true;
@@ -103,11 +103,11 @@ function research_start($pcid,$track)
     }
     $calc = research_calculate($row['base_cost'],$row['cost_mult'],$row['base_time_min'],$row['time_mult'],$target);
     if ($pc['credits'] < $calc['cost']) {
-        return array('error'=>'Nicht gen&uuml;gend Credits');
+        return array('error'=>'Nicht genügend Credits');
     }
     db_query('UPDATE pcs SET credits=credits-'.mysql_escape_string($calc['cost']).' WHERE id=\''.mysql_escape_string($pcid).'\' AND credits>='.mysql_escape_string($calc['cost']).'');
     if (mysql_affected_rows() < 1) {
-        return array('error'=>'Nicht gen&uuml;gend Credits');
+        return array('error'=>'Nicht genügend Credits');
     }
     $pc['credits'] -= $calc['cost'];
     $start = time();

--- a/research.php
+++ b/research.php
@@ -23,7 +23,7 @@ if ($action === 'cancel') {
     if (research_cancel($pcid, $id)) {
         header('Location: research.php?sid='.$sid.'&ok='.urlencode('Forschung abgebrochen'));
     } else {
-        header('Location: research.php?sid='.$sid.'&error='.urlencode('Abbruch nicht m&ouml;glich'));
+        header('Location: research.php?sid='.$sid.'&error='.urlencode('Abbruch nicht möglich'));
     }
     exit;
 }
@@ -40,7 +40,7 @@ createlayout_top('ZeroDayEmpire - Forschung');
 
 echo '<div class="content" id="computer">'."\n";
 echo '<h2>Forschung</h2>'."\n";
-echo '<div class="submenu"><p><a href="game.php?m=start&amp;sid='.$sid.'">Zur &Uuml;bersicht</a></p></div>'."\n";
+echo '<div class="submenu"><p><a href="game.php?m=start&amp;sid='.$sid.'">Zur Übersicht</a></p></div>'."\n";
 
 if (!function_exists('infobox')) {
     function infobox($titel, $class, $text, $param = 'class')
@@ -78,7 +78,7 @@ if ($full > 0) {
         $name = mysql_result($ti,0,'name');
         $cur = $states[$row['track']] ?? ($row['target_level']-1);
         $next = $row['target_level'];
-        echo '<tr><th>'.htmlspecialchars($name).'</th><td>L'.$cur.' &raquo; L'.$next.'</td>';
+        echo '<tr><th>'.htmlspecialchars($name).'</th><td>L'.$cur.' » L'.$next.'</td>';
         echo '<td>'.nicetime($row['end']).'</td>';
         echo '<td><a href="research.php?a=cancel&amp;id='.$row['id'].'&amp;sid='.$sid.'">Abbrechen</a></td></tr>'."\n";
         $states[$row['track']] = $next;
@@ -91,10 +91,10 @@ if ($full > 0) {
 
 if ($full < $maxSlots) {
     $tracks = research_get_tracks();
-    echo '<h3>Verf&uuml;gbare Forschung</h3>';
+    echo '<h3>Verfügbare Forschung</h3>';
     echo '<p><strong>Geld: '.number_format($pc['credits'],0,',','.').' Credits</strong></p>'."\n";
     echo '<table>'."\n";
-    echo '<tr><th>Zweig</th><th>Level</th><th>Dauer</th><th>Kosten</th><th>Start</th></tr>'."\n";
+    echo '<tr><th>Zweig</th><th>Level</th><th>Dauer</th><th>Kosten</th><th>Erforschen</th></tr>'."\n";
     foreach ($tracks as $track => $info) {
         $cur = $info['level'];
         $max = $info['max_level'];
@@ -113,16 +113,16 @@ if ($full < $maxSlots) {
         $can = ($dep === true);
         echo '<td>'.$timeStr.'</td><td>'.$info['next_cost'].' Credits</td><td>';
         if ($can && $pc['credits'] >= $info['next_cost']) {
-            echo '<a href="research.php?a=start&amp;track='.$track.'&amp;sid='.$sid.'">Start</a>';
+            echo '<a href="research.php?a=start&amp;track='.$track.'&amp;sid='.$sid.'">Erforschen</a>';
         } else {
-            $msg = $can ? 'Nicht gen&uuml;gend Credits' : $dep;
-            echo '<span title="'.htmlspecialchars($msg).'">Start</span>';
+            $msg = $can ? 'Nicht genügend Credits' : $dep;
+            echo '<span title="'.htmlspecialchars($msg).'">Erforschen</span>';
         }
         echo '</td></tr>'."\n";
     }
     echo '</table>';
 } else {
-    echo '<h3>Verf&uuml;gbare Forschung</h3><p>Alle Slots belegt.</p>';
+    echo '<h3>Verfügbare Forschung</h3><p>Alle Slots belegt.</p>';
 }
 
 echo "\n".'</div>'."\n";


### PR DESCRIPTION
## Summary
- Replace "Start" with "Erforschen" on the research page and display umlauts directly
- Add `mysql_affected_rows()` wrapper for mysqli compatibility

## Testing
- `php -l research.php`
- `php -l includes/research.php`
- `php -l gres.php`


------
https://chatgpt.com/codex/tasks/task_b_68b043523f348325a01a6dcfaf2f04cb