### PR TITLE
Reorder top navigation menu

### DIFF
--- a/layout.php
+++ b/layout.php
@@ -66,11 +66,10 @@ function createlayout_top($title = 'ZeroDayEmpire', $nomenu = false)
         echo '<nav class="nav-links" id="navList" aria-label="Hauptnavigation">';
         if ($sid !== '') {
             echo '<a href="game.php?m=start' . $sid . '">Übersicht</a>';
-            echo '<a href="mail.php?m=start' . $sid . '">Messages</a>';
             echo '<a href="cluster.php?a=start' . $sid . '">Cluster</a>';
             echo '<a href="research.php?sid=' . $usr['sid'] . '">Research</a>';
-            echo '<a href="user.php?a=config' . $sid . '">Optionen</a>';
             echo '<a href="ranking.php?m=ranking' . $sid . '">Rangliste</a>';
+            echo '<a href="user.php?a=config' . $sid . '">Optionen</a>';
             echo '<a href="login.php?a=logout' . $sid . '">Abmelden</a>';
         } else {
             echo '<a href="pub.php?a=register" id="registerLink">Registrieren</a>';


### PR DESCRIPTION
## Summary
- Arrange header navigation to display Overview, Cluster, Research, Ranking, Options, Logout.
- Remove unused Messages link.

## Testing
- `php -l layout.php`


------
https://chatgpt.com/codex/tasks/task_b_68b512eddb9c8325a67434d4749a814a