### PR TITLE
Move upgrade definitions into database

### DIFF
--- a/game.php
+++ b/game.php
@@ -202,8 +202,8 @@ switch ($action) {
       <h3>Computer</h3>
       <ul class="muted" style="list-style:none; padding-left:0; margin:10px 0 0 0">
         <li><a href="game.php?m=pc&amp;sid=<?php echo $sid; ?>"><strong><?php echo safeentities($pc['name']); ?></strong> (10.47.<?php echo $pc['ip']; ?>)</a></li>
-        <li data-item="cpu"><?php echo idtoname('cpu'); ?>: <?php echo $cpu_names[$pc['cpu']]; ?><?php echo overview_upgrade_link('cpu'); ?><div class="tip"></div></li>
-        <li data-item="ram"><?php echo idtoname('ram'); ?>: <?php echo $ram_levels[$pc['ram']]; ?> MB<?php echo overview_upgrade_link('ram'); ?><div class="tip"></div></li>
+          <li data-item="cpu"><?php echo idtoname('cpu'); ?>: <?php echo formatitemlevel('cpu',$pc['cpu']); ?><?php echo overview_upgrade_link('cpu'); ?><div class="tip"></div></li>
+          <li data-item="ram"><?php echo idtoname('ram'); ?>: <?php echo formatitemlevel('ram',$pc['ram']); ?><?php echo overview_upgrade_link('ram'); ?><div class="tip"></div></li>
         <li data-item="lan"><?php echo idtoname('lan'); ?>: Level <?php echo $pc['lan']; ?><?php echo overview_upgrade_link('lan'); ?><div class="tip"></div></li>
       </ul>
       <div class="software">
@@ -327,23 +327,16 @@ createlayout_bottom();
 
         function showinfo($id, $txt, $val = -1)
         {
-            global $pc, $sid, $pcid, $usrid, $ram_levels, $cpu_levels, $cpu_names;
+            global $pc, $sid, $pcid, $usrid;
             if ($val == -1) {
                 $val = $pc[$id];
             }
-            if ($id == 'ram') {
-                $val = $ram_levels[$val];
-            } elseif ($id == 'cpu') {
-                $val = $cpu_names[$val];
-            }
             $name = idtoname($id);
-            if ($val && $val != '0.0') {
-                if (strlen((string)$val) == 1 || $val == 10) {
-                    $val = $val.'.0';
-                }
+            $disp = formatitemlevel($id, $val);
+            if ($disp && $disp != '0.0') {
                 echo '<a href="game.php?m=item&amp;item='.$id.'&amp;sid='.$sid.'">'.$name.'</a>';
                 if ($txt != '') {
-                    echo ' ('.str_replace('%v', $val, $txt).')';
+                    echo ' ('.str_replace('%v', $disp, $txt).')';
                 }
                 echo "\n";
             }
@@ -497,16 +490,7 @@ createlayout_bottom();
 <?php // /ZDE theme inject start
 
 
-        $val = $pcItemValue;
-        if ($item == 'ram') {
-            $val = $ram_levels[$val];
-        } elseif ($item == 'cpu') {
-            $val = $cpu_names[$val];
-        } else {
-            if (strlen((string)$val) == 1) {
-                $val = $val.'.0';
-            }
-        }
+        $val = formatitemlevel($item, $pcItemValue);
 
         $cssid = 'essential';
         if ($item == 'sdk' || $item == 'mk' || $item == 'ips') {
@@ -768,7 +752,7 @@ createlayout_bottom();
             function buildinfo($id)
             {
                 global $STYLESHEET, $DATADIR, $pc, $bucks, $sid, $usrid, $pcid;
-                global $ram_levels, $cpu_levels, $r, $full, $SALT, $idparam;
+                global $r, $full, $SALT, $idparam;
                 if (isavailb($id, $pc)) {
                     $inf = getiteminfo($id, $pc[$id]);
 

--- a/gres.php
+++ b/gres.php
@@ -189,68 +189,17 @@ if ($localhost) {
     setlocale(LC_TIME, 'de_DE');
 }
 
-$cpu_levels = array(
-    0 => 1200,
-    1 => 1400,
-    2 => 1600,
-    3 => 1800,
-    4 => 2000,
-    5 => 2200,
-    6 => 2400,
-    7 => 2600,
-    8 => 2800,
-    9 => 3000,
-    10 => 3200,
-    11 => 3400,
-    12 => 3600,
-    13 => 3800,
-    14 => 4000,
-    15 => 4200,
-    16 => 4400,
-    17 => 4600,
-    18 => 4800,
-    19 => 5000,
-    20 => 5200,
-    21 => 5400,
-);
-
-$cpu_names = array(
-    0 => 'Single-Core 1200 Ghz',
-    1 => 'Single-Core 1400 Ghz',
-    2 => 'Single-Core 1600 Ghz',
-    3 => 'Single-Core 1800 Ghz',
-    4 => 'Dual-Core 2x2000 Ghz',
-    5 => 'Dual-Core 2x2200 Ghz',
-    6 => 'Dual-Core 2x2400 Ghz',
-    7 => 'Dual-Core 2x2600 Ghz',
-    8 => 'Dual-Core 2x2800 Ghz',
-    9 => 'Dual-Core 2x3000 Ghz',
-    10 => 'Dual-Core 4x3200 Ghz',
-    11 => 'Quad-Core 4x3400 Ghz',
-    12 => 'Quad-Core 4x3600 Ghz',
-    13 => 'Quad-Core 4x3800 Ghz',
-    14 => 'Quad-Core 4x4000 Ghz',
-    15 => 'Quad-Core 4x4200 Ghz',
-    16 => 'Quad-Core 4x4400 Ghz',
-    17 => 'Quad-Core 4x4600 Ghz',
-    18 => 'Quad-Core 4x4800 Ghz',
-    19 => 'Quad-Core 4x5000 Ghz',
-    20 => 'Quad-Core 4x5200 Ghz',
-    21 => 'Quad-Core 4x5400 Ghz',
-);
-
-$ram_levels = array(
-    0 => 1024,
-    1 => 2048,
-    2 => 3072,
-    3 => 4096,
-    4 => 5120,
-    5 => 6144,
-    6 => 7168,
-    7 => 8192,
-    8 => 9216,
-    9 => 10240,
-);
+$cpu_levels = $cpu_names = $ram_levels = array();
+$r = db_query("SELECT level,value,name FROM item_levels WHERE item='cpu' ORDER BY level");
+while ($row = mysql_fetch_assoc($r)) {
+    $lvl = (int)$row['level'];
+    $cpu_levels[$lvl] = (int)$row['value'];
+    $cpu_names[$lvl] = $row['name'];
+}
+$r = db_query("SELECT level,value FROM item_levels WHERE item='ram' ORDER BY level");
+while ($row = mysql_fetch_assoc($r)) {
+    $ram_levels[(int)$row['level']] = (int)$row['value'];
+}
 
 define('DPH_ADS', 22, false);
 define('DPH_DIALER', 24, false);
@@ -1037,23 +986,16 @@ function processupgrades(&$pc, $savepc = true)
 function itemmaxval($id)
 { //-------------------- ITEM MAX VALUE ------------------------
     global $cpu_levels, $ram_levels;
-    switch ($id) {
-        case 'cpu':
-            return count($cpu_levels) - 1;
-            break;
-        case 'ram':
-            return count($ram_levels) - 1;
-            break;
-        case 'sdk':
-            return 5;
-            break;
-        case 'trojan':
-            return 5;
-            break;
-        default:
-            return 10;
-            break;
+    if ($id == 'cpu') {
+        return count($cpu_levels) - 1;
+    } elseif ($id == 'ram') {
+        return count($ram_levels) - 1;
     }
+    $r = db_query('SELECT max_level FROM item_formulas WHERE item=\''.mysql_escape_string($id).'\' LIMIT 1;');
+    if ($row = mysql_fetch_assoc($r)) {
+        return (float)$row['max_level'];
+    }
+    return 10;
 }
 
 function itemnextlevel($id, $curlevel)

--- a/ingame.php
+++ b/ingame.php
@@ -243,214 +243,39 @@ function cscodetostring($code)
 }
 
 
+
 function getiteminfo($key, $stage)
 { //--------------------- Get Item Info --------------------------
-    global $STYLESHEET, $REMOTE_FILES_DIR, $DATADIR, $pc;
-    global $cpu_levels, $ram_levels;
-    $d;
-    $c;
+    global $pc;
+    $c = $d = 0;
     if ($stage < 1) {
         $stage = 1;
     }
     $stage = (float)$stage;
-    switch ($key) {
-        case 'cpu':
-            switch ($stage) {
-                case 0:
-                    $d = 20;
-                    $c = 60;
-                    break;
-                case 1:
-                    $d = 25;
-                    $c = 80;
-                    break;
-                case 2:
-                    $d = 30;
-                    $c = 90;
-                    break;
-                case 3:
-                    $d = 35;
-                    $c = 110;
-                    break;
-                case 4:
-                    $d = 40;
-                    $c = 120;
-                    break;
-                case 5:
-                    $d = 45;
-                    $c = 140;
-                    break;
-                case 6:
-                    $d = 50;
-                    $c = 150;
-                    break;
-                case 7:
-                    $d = 55;
-                    $c = 255;
-                    break;
-                case 8:
-                    $d = 55;
-                    $c = 300;
-                    break;
-                case 9:
-                    $d = 60;
-                    $c = 512;
-                    break;
-                case 10:
-                    $d = 90;
-                    $c = 768;
-                    break;
-                case 11:
-                    $d = 120;
-                    $c = 1150;
-                    break;
-                case 12:
-                    $d = 150;
-                    $c = 1730;
-                    break;
-                case 13:
-                    $d = 180;
-                    $c = 2590;
-                    break;
-                case 14:
-                    $d = 210;
-                    $c = 3890;
-                    break;
-                case 15:
-                    $d = 240;
-                    $c = 5800;
-                    break;
-                case 16:
-                    $d = 300;
-                    $c = 8500;
-                    break;
-                case 17:
-                    $d = 360;
-                    $c = 12000;
-                    break;
-                case 18:
-                    $d = 420;
-                    $c = 18000;
-                    break;
-                case 19:
-                    $d = 460;
-                    $c = 25000;
-                    break;
-                case 20:
-                    $d = 580;
-                    $c = 50000;
-                    break;
-            }
-            break;
-        case 'ram':
-            switch ($stage) {
-                case 0:
-                    $d = 30;
-                    $c = 200;
-                    break;
-                case 1:
-                    $d = 45;
-                    $c = 300;
-                    break;
-                case 2:
-                    $d = 60;
-                    $c = 500;
-                    break;
-                case 3:
-                    $d = 70;
-                    $c = 800;
-                    break;
-                case 4:
-                    $d = 90;
-                    $c = 1000;
-                    break;
-                case 5:
-                    $d = 120;
-                    $c = 1200;
-                    break;
-                case 6:
-                    $d = 150;
-                    $c = 3000;
-                    break;
-                case 7:
-                    $d = 180;
-                    $c = 4000;
-                    break;
-                case 8:
-                    $d = 210;
-                    $c = 10000;
-                    break;
-            }
-            break;
-        case 'mm':
-            $stage += 0.5;
-            $c = $stage * 51;
-            $d = $stage * 10;
-            break;
-        case 'bb':
-            $stage += 0.5;
-            $c = $stage * 45;
-            $d = $stage * 11;
-            break;
-        case 'lan':
-            $stage += 0.5;
-            $c = $stage * 150;
-            $d = $stage * 25;
-            break;
-        case 'sdk':
-            $stage += 0.5;
-            $c = $stage * 100;
-            $d = $stage * 15;
-            break;
-        case 'fw':
-            $stage += 0.5;
-            $c = $stage * 49;
-            $d = $stage * 5;
-            break;
-        case 'av':
-            $stage += 0.15;
-            $c = $stage * 50;
-            $d = $stage * 6;
-            break;
-        case 'mk':
-            $stage += 0.5;
-            $c = $stage * 100;
-            $d = $stage * 16;
-            break;
-        case 'ips':
-            $stage += 0.5;
-            $c = $stage * 33;
-            $d = $stage * 8;
-            break;
-        case 'ids':
-            $stage += 0.5;
-            $c = $stage * 44;
-            $d = $stage * 7;
-            break;
-        case 'rh':
-            $stage += 0.5;
-            $c = $stage * 400;
-            $d = $stage * 10;
-            break;
-        case 'trojan':
-            $stage += 0.5;
-            $c = $stage * 39;
-            $d = $stage * 8;
-            break;
+    $cost_mult = 1;
+    if ($key == 'cpu' || $key == 'ram') {
+        $res = db_query('SELECT next_cost,next_duration FROM item_levels WHERE item=\''.mysql_escape_string($key).'\' AND level=\''.mysql_escape_string((int)$stage).'\' LIMIT 1;');
+        if ($row = mysql_fetch_assoc($res)) {
+            $c = (int)$row['next_cost'];
+            $d = (int)$row['next_duration'];
+        }
+    } else {
+        $res = db_query('SELECT offset,cost_factor,duration_factor,cost_multiplier FROM item_formulas WHERE item=\''.mysql_escape_string($key).'\' LIMIT 1;');
+        if ($row = mysql_fetch_assoc($res)) {
+            $stage += (float)$row['offset'];
+            $c = $stage * (float)$row['cost_factor'];
+            $d = $stage * (float)$row['duration_factor'];
+            $cost_mult = (float)$row['cost_multiplier'];
+        }
     }
-
-    $r['c'] = ceil($c); # Kosten
-    $r['d'] = floor($d); # Dauer in Minuten
+    $r = array('c' => ceil($c), 'd' => floor($d));
     if ($key != 'cpu' && $key != 'ram') {
-        $r['c'] *= 4;
+        $r['c'] *= $cost_mult;
         $df = duration_faktor($pc['cpu'], $pc['ram']);
-        $r['d'] *= $df;
+        $r['d'] = ceil($r['d'] * $df);
         $r['c'] = floor($r['c']);
-        $r['d'] = ceil($r['d']);
     }
-
     return $r;
-
 }
 
 function duration_faktor($cpu, $ram)

--- a/sql/2025-10-07_item_levels.sql
+++ b/sql/2025-10-07_item_levels.sql
@@ -1,0 +1,69 @@
+-- Migration: move item upgrade data to database
+-- Target: MariaDB 10.x
+
+CREATE TABLE IF NOT EXISTS `item_levels` (
+  `item` varchar(16) NOT NULL,
+  `level` tinyint unsigned NOT NULL,
+  `value` int unsigned DEFAULT NULL,
+  `name` varchar(100) DEFAULT NULL,
+  `next_cost` int unsigned NOT NULL DEFAULT 0,
+  `next_duration` int unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`item`,`level`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `item_formulas` (
+  `item` varchar(16) NOT NULL,
+  `offset` decimal(4,2) NOT NULL DEFAULT 0.50,
+  `cost_factor` decimal(10,2) NOT NULL,
+  `duration_factor` decimal(10,2) NOT NULL,
+  `cost_multiplier` decimal(10,2) NOT NULL DEFAULT 4.00,
+  `max_level` decimal(5,2) NOT NULL DEFAULT 10.00,
+  PRIMARY KEY (`item`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+REPLACE INTO `item_levels` (`item`,`level`,`value`,`name`,`next_cost`,`next_duration`) VALUES
+  ('cpu',0,1200,'Single-Core 1200 Ghz',60,20),
+  ('cpu',1,1400,'Single-Core 1400 Ghz',80,25),
+  ('cpu',2,1600,'Single-Core 1600 Ghz',90,30),
+  ('cpu',3,1800,'Single-Core 1800 Ghz',110,35),
+  ('cpu',4,2000,'Dual-Core 2x2000 Ghz',120,40),
+  ('cpu',5,2200,'Dual-Core 2x2200 Ghz',140,45),
+  ('cpu',6,2400,'Dual-Core 2x2400 Ghz',150,50),
+  ('cpu',7,2600,'Dual-Core 2x2600 Ghz',255,55),
+  ('cpu',8,2800,'Dual-Core 2x2800 Ghz',300,55),
+  ('cpu',9,3000,'Dual-Core 2x3000 Ghz',512,60),
+  ('cpu',10,3200,'Dual-Core 4x3200 Ghz',768,90),
+  ('cpu',11,3400,'Quad-Core 4x3400 Ghz',1150,120),
+  ('cpu',12,3600,'Quad-Core 4x3600 Ghz',1730,150),
+  ('cpu',13,3800,'Quad-Core 4x3800 Ghz',2590,180),
+  ('cpu',14,4000,'Quad-Core 4x4000 Ghz',3890,210),
+  ('cpu',15,4200,'Quad-Core 4x4200 Ghz',5800,240),
+  ('cpu',16,4400,'Quad-Core 4x4400 Ghz',8500,300),
+  ('cpu',17,4600,'Quad-Core 4x4600 Ghz',12000,360),
+  ('cpu',18,4800,'Quad-Core 4x4800 Ghz',18000,420),
+  ('cpu',19,5000,'Quad-Core 4x5000 Ghz',25000,460),
+  ('cpu',20,5200,'Quad-Core 4x5200 Ghz',50000,580),
+  ('cpu',21,5400,'Quad-Core 4x5400 Ghz',0,0),
+  ('ram',0,1024,NULL,200,30),
+  ('ram',1,2048,NULL,300,45),
+  ('ram',2,3072,NULL,500,60),
+  ('ram',3,4096,NULL,800,70),
+  ('ram',4,5120,NULL,1000,90),
+  ('ram',5,6144,NULL,1200,120),
+  ('ram',6,7168,NULL,3000,150),
+  ('ram',7,8192,NULL,4000,180),
+  ('ram',8,9216,NULL,10000,210),
+  ('ram',9,10240,NULL,0,0);
+
+REPLACE INTO `item_formulas` (`item`,`offset`,`cost_factor`,`duration_factor`,`cost_multiplier`,`max_level`) VALUES
+  ('mm',0.50,51,10,4,10.0),
+  ('bb',0.50,45,11,4,10.0),
+  ('lan',0.50,150,25,4,10.0),
+  ('sdk',0.50,100,15,4,5.0),
+  ('fw',0.50,49,5,4,10.0),
+  ('av',0.15,50,6,4,10.0),
+  ('mk',0.50,100,16,4,10.0),
+  ('ips',0.50,33,8,4,10.0),
+  ('ids',0.50,44,7,4,10.0),
+  ('rh',0.50,400,10,4,10.0),
+  ('trojan',0.50,39,8,4,5.0);


### PR DESCRIPTION
## Summary
- load CPU/RAM specifications and upgrade formulas from database
- compute item costs and durations from new tables
- use formatted item levels instead of hard-coded arrays

## Testing
- `php -l ingame.php`
- `php -l gres.php`
- `php -l game.php`
- `php -l research.php`


------
https://chatgpt.com/codex/tasks/task_b_68b513fa810083259e52ff9c4b8bc911