### PR TITLE
Ensure default database selected on bootstrap

### DIFF
--- a/gres.php
+++ b/gres.php
@@ -172,6 +172,9 @@ function dbname($srvid = -1)
     return $database_prefix.$srvid.$database_suffix;
 }
 
+// Ensure a database is selected before any queries run
+mysql_select_db(dbname(1));
+
 function db_query($q)
 {
     global $dbcon;

--- a/index.php
+++ b/index.php
@@ -2,7 +2,6 @@
 // Fetch champion name for KPI display
 define('IN_ZDE', 1);
 require_once __DIR__ . '/gres.php';
-mysql_select_db(dbname(1));
 $champion = '';
 $r = db_query('SELECT name FROM rank_users ORDER BY platz ASC LIMIT 1;');
 if ($row = mysql_fetch_assoc($r)) {


### PR DESCRIPTION
## Summary
- Select standard database in `gres.php` immediately after defining the helper, preventing missing-selection errors
- Drop redundant `mysql_select_db` call from `index.php`

## Testing
- `php -l gres.php index.php`


------
https://chatgpt.com/codex/tasks/task_b_68c01d30345083259eccbbd8a72a5e39