### PR TITLE
feat: unify tooltip styling

### DIFF
--- a/research.php
+++ b/research.php
@@ -97,7 +97,7 @@ foreach ($tracks as $track => $info) {
     $cur = $info['level'];
     $max = $info['max_level'];
     $tooltipText = str_replace("\n", '&#10;', htmlspecialchars($trackTooltips[$track] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
-    echo '<tr><td'.($tooltipText ? ' data-tooltip="'.$tooltipText.'"' : '').'>'.htmlspecialchars($info['name']).'</td><td>'.$cur.'/'.$max.'</td>';
+    echo '<tr><td'.($tooltipText ? ' class="tooltip" data-tooltip="'.$tooltipText.'"' : '').'>'.htmlspecialchars($info['name']).'</td><td>'.$cur.'/'.$max.'</td>';
     if ($cur >= $max) {
         echo '<td colspan="3">Max</td></tr>'."\n";
         continue;

--- a/style.css
+++ b/style.css
@@ -205,9 +205,11 @@ table tbody tr:hover{
 }
 table tbody tr:last-child td{ border-bottom:none }
 
-/* Tooltips */
-[data-tooltip]{ position:relative; cursor:help }
-[data-tooltip]:hover::after{
+/* Tooltip styling
+   Elements can either set a data-tooltip attribute or use the tooltip class
+   to display a unified hover tooltip across the project. */
+[data-tooltip], .tooltip { position:relative; cursor:help }
+[data-tooltip]:hover::after, .tooltip:hover::after {
   content: attr(data-tooltip);
   position:absolute;
   left:0; top:calc(100% + 6px);


### PR DESCRIPTION
## Summary
- promote research tooltip styles to global `.tooltip` class in style.css
- use class on research branch listing to showcase usage

## Testing
- `php -l research.php`


------
https://chatgpt.com/codex/tasks/task_b_68c539d5e0b083259e808738166d35a3