### PR TITLE
Refactor research interface

### DIFF
--- a/research.php
+++ b/research.php
@@ -1,52 +1,94 @@
 <?php
 define('IN_ZDE', 1);
 $FILE_REQUIRES_PC = true;
-// Load the common game bootstrap. Using an absolute path via __DIR__
-// avoids include_path issues that previously resulted in the script
-// terminating with "Hacking attempt" when the file could not be found.
 require_once __DIR__.'/ingame.php';
 
-$action = $_REQUEST['a'] ?? $_REQUEST['action'] ?? $_REQUEST['m'] ?? $_REQUEST['page'] ?? '';
+$action = $_REQUEST['a'] ?? $_REQUEST['action'] ?? '';
 
-if ($action === 'start') {
-    $track = $_GET['track'] ?? '';
-    $res = research_start($pcid, $track);
-    if (isset($res['error'])) {
-        header('Location: research.php?sid='.$sid.'&error='.urlencode($res['error']));
-    } else {
-        header('Location: research.php?sid='.$sid.'&ok='.urlencode('Forschung gestartet'));
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($action === 'start') {
+        $track = $_POST['track'] ?? '';
+        $res = research_start($pcid, $track);
+        header('Content-Type: application/json');
+        if (isset($res['error'])) {
+            $reason = 'deps';
+            if ($res['error'] === 'Nicht genügend Credits') {
+                $reason = 'credits';
+            } elseif ($res['error'] === 'Keine freien Slots') {
+                $reason = 'slots';
+            }
+            echo json_encode(['ok' => false, 'reason' => $reason]);
+        } else {
+            echo json_encode(['ok' => true]);
+        }
+        exit;
     }
-    exit;
-}
-if ($action === 'cancel') {
-    $id = (int)($_GET['id'] ?? 0);
-    if (research_cancel($pcid, $id)) {
-        header('Location: research.php?sid='.$sid.'&ok='.urlencode('Forschung abgebrochen'));
-    } else {
-        header('Location: research.php?sid='.$sid.'&error='.urlencode('Abbruch nicht möglich'));
+    if ($action === 'cancel') {
+        $id = (int)($_POST['id'] ?? 0);
+        $ok = research_cancel($pcid, $id);
+        header('Content-Type: application/json');
+        echo json_encode(['ok' => $ok]);
+        exit;
     }
-    exit;
 }
 
 processupgrades($pc);
 if ($pc['blocked'] > time()) { exit; }
 
+function format_duration($seconds) {
+    $seconds = (int)$seconds;
+    $h = floor($seconds / 3600);
+    $m = floor(($seconds % 3600) / 60);
+    if ($h > 0) {
+        return $m > 0 ? $h.' h '.$m.' min' : $h.' h';
+    }
+    return $m.' min';
+}
+function format_credits($n) {
+    return number_format((int)$n, 0, ',', '.').' Credits';
+}
+function dependency_badge($ok) {
+    return $ok
+        ? '<span class="badge ok">Erfüllte Abhängigkeit</span>'
+        : '<span class="badge muted">Abhängigkeit fehlt</span>';
+}
+
 createlayout_top('ZeroDayEmpire - Forschung');
-echo '<div class="content" id="computer">'."\n";
-echo '<h2>Forschung</h2>'."\n";
-echo '<div class="submenu"><p><a href="game.php?m=start&amp;sid='.$sid.'">Zur Übersicht</a></p></div>'."\n";
 
+echo '<header class="page-head"><h1>Forschung</h1><a href="game.php?m=start&amp;sid='.$sid.'" class="btn ghost sm">Zur Übersicht</a></header>';
 
-$notif = '';
-if (!empty($_GET['ok'])) {
-    $notif .= '<div class="ok"><h3>OK</h3><p>'.htmlspecialchars($_GET['ok']).'</p></div>';
+$now = time();
+$runningRows = [];
+$r = db_query('SELECT * FROM research WHERE pc=\''.mysql_escape_string($pcid).'\' AND `end`>\''.mysql_escape_string($now).'\' ORDER BY `start` ASC');
+while ($row = mysql_fetch_assoc($r)) { $runningRows[] = $row; }
+$running = count($runningRows);
+$maxSlots = isset($pc['research_slots']) ? (int)$pc['research_slots'] : 1;
+$credits = (int)$pc['credits'];
+$queueTime = $running ? $runningRows[0]['end'] - $now : 0;
+
+echo '<div class="strip">';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h18M12 3v18" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><div class="value">'.$running.' / '.$maxSlots.'</div><div class="label">Slots</div><div class="progress"><div class="bar" style="width:'.($maxSlots?($running/$maxSlots*100):0).'%;"></div></div></div></div>';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h16v12H4z" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M2 18h20" stroke="rgb(var(--accent))"/></svg><div class="stat"><div class="value" id="kpiCredits" data-value="'.$credits.'">'.format_credits($credits).'</div><div class="label">Credits</div></div></div>';
+$queueLabel = $running ? '<span class="cd" data-end="'.($now + $queueTime).'">'.sprintf('%02d:%02d', floor($queueTime/3600), floor(($queueTime%3600)/60)).'</span>' : 'Keine Forschung aktiv';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M12 7v5l3 2" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><div class="value">'.$queueLabel.'</div><div class="label">Warteschlange</div></div></div>';
+echo '</div>';
+
+if ($running > 0) {
+    $states = [];
+    $rs = db_query('SELECT track, level FROM research_state WHERE pc=\''.mysql_escape_string($pcid).'\';');
+    while ($s = mysql_fetch_assoc($rs)) { $states[$s['track']] = (int)$s['level']; }
+    echo '<section class="card list"><h2>Laufende Forschung</h2><ul class="list">';
+    foreach ($runningRows as $row) {
+        $ti = db_query('SELECT name FROM research_tracks WHERE track=\''.mysql_escape_string($row['track']).'\' LIMIT 1;');
+        $name = mysql_result($ti,0,'name');
+        $cur = $states[$row['track']] ?? ($row['target_level']-1);
+        $next = $row['target_level'];
+        echo '<li class="list-row"><span class="name">'.htmlspecialchars($name).'</span><span class="lvl">L'.$cur.'/'.$next.'</span><span class="cd" data-end="'.$row['end'].'"></span><button class="btn ghost sm cancel-btn" data-id="'.$row['id'].'">Abbrechen</button></li>';
+        $states[$row['track']] = $next;
+    }
+    echo '</ul></section>';
 }
-if (!empty($_GET['error'])) {
-    $notif .= '<div class="error"><h3>Fehler</h3><p>'.htmlspecialchars($_GET['error']).'</p></div>';
-}
-echo $notif;
- 
-// Tooltip descriptions for each research track
+
 $trackTooltips = [
     'r_ana' => "Vermittelt die Grundlagen zum Einordnen öffentlich verfügbarer Skripte/PoCs in der Simulation. Dient als Voraussetzung für fortgeschrittene Zweige.",
     'r_bauk' => "Baut wiederverwendbare Module auf, damit Funktionen in Szenarien schneller kombiniert werden können. Erhöht die Effizienz nachfolgender Forschungsschritte.",
@@ -60,69 +102,43 @@ $trackTooltips = [
     'r_veil' => "Untersucht Tarnmechaniken abstrakt innerhalb der Simulation. Unterstützt höhere Zweige, indem es Erkennungsrisiken in Szenario-Bewertungen reduziert.",
 ];
 
-$r = db_query('SELECT * FROM research WHERE pc=\''.mysql_escape_string($pcid).'\' AND `end`>\''.time().'\' ORDER BY `start` ASC;');
-$full = mysql_num_rows($r);
-$maxSlots = isset($pc['research_slots']) ? (int)$pc['research_slots'] : 1;
-
-echo '<div class="strip"><div class="kpi"><div class="label">Laufende Forschungen</div><div class="value">'.$full.' / '.$maxSlots.'</div></div>';
-echo '<div class="kpi"><div class="label">Credits</div><div class="value">'.number_format($pc['credits'],0,',','.').'</div></div></div>';
-if ($full > 0) {
-    $states = array();
-    $rs = db_query('SELECT track, level FROM research_state WHERE pc=\''.mysql_escape_string($pcid).'\';');
-    while ($s = mysql_fetch_assoc($rs)) { $states[$s['track']] = (int)$s['level']; }
-
-    echo '<h3>Laufende Forschungen</h3>'."\n";
-    echo '<table>'."\n";
-    while ($row = mysql_fetch_assoc($r)) {
-        $ti = db_query('SELECT name FROM research_tracks WHERE track=\''.mysql_escape_string($row['track']).'\' LIMIT 1;');
-        $name = mysql_result($ti,0,'name');
-        $cur = $states[$row['track']] ?? ($row['target_level']-1);
-        $next = $row['target_level'];
-        echo '<tr><th>'.htmlspecialchars($name).'</th><td>L'.$cur.' » L'.$next.'</td>';
-        echo '<td>'.nicetime($row['end']).'</td>';
-        echo '<td><a href="research.php?a=cancel&amp;id='.$row['id'].'&amp;sid='.$sid.'">Abbrechen</a></td></tr>'."\n";
-        $states[$row['track']] = $next;
-    }
-    echo '</table>'."\n";
-    echo '<p>Abbruch erstattet keine Credits.</p>';
-} else {
-    echo '<h3>Laufende Forschungen</h3><p>Keine Forschung aktiv.</p>';
-}
-
 $tracks = research_get_tracks();
-echo '<h3>Verfügbare Forschung</h3>';
-echo '<table>'."\n";
-echo '<tr><th>Zweig</th><th>Level</th><th>Dauer</th><th>Kosten</th><th>Erforschen</th></tr>'."\n";
+echo '<section class="card table-card"><h2>Verfügbare Forschung</h2><table><thead><tr><th scope="col">Zweig</th><th scope="col">Level</th><th scope="col">Dauer</th><th scope="col">Kosten</th><th scope="col">Status</th><th scope="col">Aktion</th></tr></thead><tbody>';
 foreach ($tracks as $track => $info) {
     $cur = $info['level'];
     $max = $info['max_level'];
     $tooltipText = str_replace("\n", '&#10;', htmlspecialchars($trackTooltips[$track] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
-    echo '<tr><td'.($tooltipText ? ' class="tooltip" data-tooltip="'.$tooltipText.'"' : '').'>'.htmlspecialchars($info['name']).'</td><td>'.$cur.'/'.$max.'</td>';
+    echo '<tr><td'.($tooltipText ? ' class="tooltip" data-tooltip="'.$tooltipText.'"' : '').'><strong>'.htmlspecialchars($info['name']).'</strong></td><td>'.$cur.'/'.$max.'</td>';
     if ($cur >= $max) {
-        echo '<td colspan="3">Max</td></tr>'."\n";
+        echo '<td colspan="3">Max</td><td></td></tr>';
         continue;
     }
-    $timeStr = floor($info['next_time']/60).' min';
-    if ($info['next_time'] >= 3600) {
-        $h = floor($info['next_time']/3600);
-        $m = floor(($info['next_time']/60)%60);
-        $timeStr = $h.' h'.($m>0?' '.$m.' min':'');
+    $timeStr = format_duration($info['next_time']);
+    $dep = research_check_deps($pcid, $track, $cur + 1);
+    $dep_ok = $dep === true;
+    $slotFree = ($running < $maxSlots);
+    $creditOK = $credits >= $info['next_cost'];
+    echo '<td>'.$timeStr.'</td><td>'.format_credits($info['next_cost']).'</td>';
+    echo '<td>'.dependency_badge($dep_ok).'</td>';
+    $tooltip = '';
+    if (!$dep_ok) { $tooltip = 'Abhängigkeit fehlt'; }
+    elseif (!$slotFree) { $tooltip = 'Alle Forsch-Slots belegt'; }
+    elseif (!$creditOK) { $tooltip = 'Zu wenig Credits'; }
+    $can = $dep_ok && $slotFree && $creditOK;
+    $btnAttr = 'class="btn sm start-btn" data-track="'.$track.'" data-cost="'.$info['next_cost'].'" data-duration="'.$info['next_time'].'"';
+    if (!$can) {
+        $btnAttr .= ' disabled aria-disabled="true"'.($tooltip ? ' data-tooltip="'.$tooltip.'"' : '');
     }
-    $dep = research_check_deps($pcid,$track,$cur+1);
-    $slotFree = ($full < $maxSlots);
-    echo '<td>'.$timeStr.'</td><td>'.$info['next_cost'].' Credits</td><td>';
-    if ($dep === true && $slotFree && $pc['credits'] >= $info['next_cost']) {
-        echo '<a href="research.php?a=start&amp;track='.$track.'&amp;sid='.$sid.'">Erforschen</a>';
-    } else {
-        if ($dep !== true) { $msg = $dep; $btn = 'Fehlende Abhängigkeit'; }
-        elseif (!$slotFree) { $msg = 'Alle Slots belegt'; $btn = 'Erforschen'; }
-        else { $msg = 'Nicht genügend Credits'; $btn = 'Erforschen'; }
-        echo '<span title="'.htmlspecialchars($msg).'">'.$btn.'</span>';
-    }
-    echo '</td></tr>'."\n";
+    echo '<td><button '.$btnAttr.'>Erforschen</button></td></tr>';
 }
-echo '</table>';
+echo '</tbody></table></section>';
 
-echo "\n".'</div>'."\n";
+echo '<script>
+function updTimers(){document.querySelectorAll(".cd").forEach(function(el){var end=parseInt(el.dataset.end,10);var s=end-Math.floor(Date.now()/1000);if(s<0)s=0;var h=Math.floor(s/3600),m=Math.floor((s%3600)/60),sec=s%60;el.textContent=(h>0?String(h).padStart(2,"0")+":"+String(m).padStart(2,"0"):String(m).padStart(2,"0"))+":"+String(sec).padStart(2,"0");});}
+updTimers();setInterval(updTimers,1000);
+document.querySelectorAll(".start-btn").forEach(function(btn){btn.addEventListener("click",function(){if(btn.disabled)return;btn.disabled=true;var track=btn.dataset.track;var cost=parseInt(btn.dataset.cost,10);var old=btn.textContent;btn.innerHTML="<span class=\"spinner\"></span>";fetch("research.php?a=start&sid='.$sid.'",{method:"POST",headers:{"Content-Type":"application/x-www-form-urlencoded"},body:"track="+encodeURIComponent(track)}).then(function(r){return r.json();}).then(function(data){if(data.ok){var c=document.getElementById("kpiCredits");var nv=parseInt(c.dataset.value,10)-cost;c.dataset.value=nv;c.textContent=nv.toLocaleString("de-DE")+" Credits";btn.textContent="Gestartet";}else{btn.textContent=old;btn.disabled=false;}});});});
+document.querySelectorAll(".cancel-btn").forEach(function(btn){btn.addEventListener("click",function(){var id=btn.dataset.id;fetch("research.php?a=cancel&sid='.$sid.'",{method:"POST",headers:{"Content-Type":"application/x-www-form-urlencoded"},body:"id="+id}).then(function(r){return r.json();}).then(function(data){if(data.ok){location.reload();}});});});
+</script>';
 
 createlayout_bottom();
+?>

--- a/style.css
+++ b/style.css
@@ -262,3 +262,29 @@ pre, code{ background: var(--bg-2); border:1px solid var(--border); border-radiu
   .content{ padding: 12px }
   .content table{ display:block; overflow:auto }
 }
+.page-head{display:flex;align-items:center;justify-content:space-between;margin:24px 0 18px;}
+.page-head h1{margin:0;}
+.kpi-icon{justify-content:flex-start;gap:12px;}
+.kpi-icon .icon{width:24px;height:24px;}
+.kpi-icon .stat{flex:1;}
+.kpi-icon .label{color:var(--muted);font-size:13px;margin-top:2px;}
+.kpi-icon .progress{margin-top:6px;}
+.badge{display:inline-block;padding:4px 6px;border-radius:8px;font-size:12px;}
+.badge.ok{background:rgba(0,210,120,.1);color:#00d278;border:1px solid rgba(0,210,120,.4);}
+.badge.muted{background:rgba(255,255,255,.05);color:var(--muted);border:1px solid var(--border);}
+.card.list{padding:0;}
+.card.list h2{padding:18px 18px 0;margin:0;}
+.list{list-style:none;margin:0;padding:0;}
+.list-row{display:flex;align-items:center;gap:12px;padding:12px 18px;border-top:1px solid var(--border);}
+.list-row:first-child{border-top:none;}
+.list-row .name{flex:1;font-weight:600;}
+.table-card{margin-top:36px;overflow:auto;}
+.table-card table{width:100%;border-collapse:collapse;}
+.table-card thead th{position:sticky;top:0;background:rgba(255,255,255,.03);text-align:left;}
+.table-card tbody tr:nth-child(even){background:rgba(255,255,255,.02);}
+.table-card th, .table-card td{padding:10px 12px;border-bottom:1px dashed var(--border);}
+.table-card tbody tr:last-child td{border-bottom:none;}
+.spinner{width:16px;height:16px;border:2px solid rgba(255,255,255,.3);border-top-color:rgba(255,255,255,.9);border-radius:50%;animation:spin .6s linear infinite;}
+@keyframes spin{to{transform:rotate(360deg);}}
+@media(max-width:1024px){.strip{grid-template-columns:repeat(2,1fr);}}
+@media(max-width:640px){.strip{grid-template-columns:1fr;}}


### PR DESCRIPTION
## Summary
- Redesign research.php to share typography and layout with the front page
- Add KPI cards, progress bars, badges and AJAX start/cancel handlers
- Extend global stylesheet with page header, responsive grid and badge utilities

## Testing
- `php -l research.php`


------
https://chatgpt.com/codex/tasks/task_b_68c53ba065708325b3f20f8d899fbb24