### PR TITLE
Refine research layout and styling

### DIFF
--- a/research.php
+++ b/research.php
@@ -7,7 +7,7 @@ $action = $_REQUEST['a'] ?? $_REQUEST['action'] ?? '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($action === 'start') {
-        $track = $_POST['track'] ?? '';
+        $track = $_POST['id'] ?? $_POST['track'] ?? '';
         $res = research_start($pcid, $track);
         header('Content-Type: application/json');
         if (isset($res['error'])) {
@@ -44,101 +44,224 @@ function format_duration($seconds) {
     }
     return $m.' min';
 }
-function format_credits($n) {
-    return number_format((int)$n, 0, ',', '.').' Credits';
-}
-function dependency_badge($ok) {
-    return $ok
-        ? '<span class="badge ok">Erfüllte Abhängigkeit</span>'
-        : '<span class="badge muted">Abhängigkeit fehlt</span>';
-}
-
-createlayout_top('ZeroDayEmpire - Forschung');
-
-echo '<header class="page-head"><h1>Forschung</h1><a href="game.php?m=start&amp;sid='.$sid.'" class="btn ghost sm">Zur Übersicht</a></header>';
 
 $now = time();
 $runningRows = [];
-$r = db_query('SELECT * FROM research WHERE pc=\''.mysql_escape_string($pcid).'\' AND `end`>\''.mysql_escape_string($now).'\' ORDER BY `start` ASC');
+$r = db_query(
+    'SELECT r.*, t.name FROM research r '
+    .'JOIN research_tracks t ON t.track=r.track '
+    .'WHERE r.pc=\''.mysql_escape_string($pcid).'\' AND r.`end`>\''.mysql_escape_string($now).'\' ORDER BY r.`end` ASC'
+);
 while ($row = mysql_fetch_assoc($r)) { $runningRows[] = $row; }
 $running = count($runningRows);
 $maxSlots = isset($pc['research_slots']) ? (int)$pc['research_slots'] : 1;
 $credits = (int)$pc['credits'];
-$queueTime = $running ? $runningRows[0]['end'] - $now : 0;
+$nextEtaTs = $running ? (int)$runningRows[0]['end'] : 0;
 
-echo '<div class="strip">';
-echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h18M12 3v18" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><div class="value">'.$running.' / '.$maxSlots.'</div><div class="label">Slots</div><div class="progress"><div class="bar" style="width:'.($maxSlots?($running/$maxSlots*100):0).'%;"></div></div></div></div>';
-echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h16v12H4z" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M2 18h20" stroke="rgb(var(--accent))"/></svg><div class="stat"><div class="value" id="kpiCredits" data-value="'.$credits.'">'.format_credits($credits).'</div><div class="label">Credits</div></div></div>';
-$queueLabel = $running ? '<span class="cd" data-end="'.($now + $queueTime).'">'.sprintf('%02d:%02d', floor($queueTime/3600), floor(($queueTime%3600)/60)).'</span>' : 'Keine Forschung aktiv';
-echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M12 7v5l3 2" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><div class="value">'.$queueLabel.'</div><div class="label">Warteschlange</div></div></div>';
-echo '</div>';
-
-if ($running > 0) {
-    $states = [];
-    $rs = db_query('SELECT track, level FROM research_state WHERE pc=\''.mysql_escape_string($pcid).'\';');
-    while ($s = mysql_fetch_assoc($rs)) { $states[$s['track']] = (int)$s['level']; }
-    echo '<section class="card list"><h2>Laufende Forschung</h2><ul class="list">';
-    foreach ($runningRows as $row) {
-        $ti = db_query('SELECT name FROM research_tracks WHERE track=\''.mysql_escape_string($row['track']).'\' LIMIT 1;');
-        $name = mysql_result($ti,0,'name');
-        $cur = $states[$row['track']] ?? ($row['target_level']-1);
-        $next = $row['target_level'];
-        echo '<li class="list-row"><span class="name">'.htmlspecialchars($name).'</span><span class="lvl">L'.$cur.'/'.$next.'</span><span class="cd" data-end="'.$row['end'].'"></span><button class="btn ghost sm cancel-btn" data-id="'.$row['id'].'">Abbrechen</button></li>';
-        $states[$row['track']] = $next;
-    }
-    echo '</ul></section>';
+$activeResearch = [];
+foreach ($runningRows as $row) {
+    $activeResearch[] = [
+        'id' => (int)$row['id'],
+        'name' => $row['name'],
+        'level' => (int)$row['target_level'],
+        'eta_text' => format_duration($row['end'] - $now)
+    ];
 }
 
-$trackTooltips = [
-    'r_ana' => "Vermittelt die Grundlagen zum Einordnen öffentlich verfügbarer Skripte/PoCs in der Simulation. Dient als Voraussetzung für fortgeschrittene Zweige.",
-    'r_bauk' => "Baut wiederverwendbare Module auf, damit Funktionen in Szenarien schneller kombiniert werden können. Erhöht die Effizienz nachfolgender Forschungsschritte.",
-    'r_c2' => "Emuliert sichere Command-&-Control-Mechaniken zur Koordination in Szenarien. Verbessert Tests zu Steuerung und Abstimmung verteilter Komponenten.",
-    'r_data' => "Analysiert und modelliert Zugriffspfade auf Daten in Systemen – rein als Szenario. Verbessert die Bewertung von Risiken/Ertrag in Simulationen.",
-    'r_lab' => "Stellt eine sichere Testumgebung bereit, um Verhalten und Wechselwirkungen zu beobachten. Reduziert Fehlversuche und ist Gate für höhere Forschung.",
-    'r_pers' => "Untersucht, wie Zustände über Szenario-Neustarts hinweg erhalten bleiben (nur simuliert). Erhöht die Beständigkeit von Effekten und öffnet Pfade zu C2/Daten.",
-    'r_poc' => "Vertieft das Verständnis von Proof-of-Concepts und sorgt für saubere Dokumentation. Erhöht Nachvollziehbarkeit und schaltet den Baukasten frei.",
-    'r_rans' => "Modelliert eine End-to-End-Architektur als reines Lern-/Balancing-Szenario ohne reale Ausführung. Gilt als komplexes Abschlussziel und bündelt Erkenntnisse aus Persistenz, Verschleierung, C2, Datenzugriff und Social Engineering.",
-    'r_se' => "Trainiert menschliche Faktoren, Kommunikation und Täuschungsmuster ohne echte Interaktion. Verbessert das Zusammenspiel mit Datenzugriff und Steuerkanal in Szenarien.",
-    'r_veil' => "Untersucht Tarnmechaniken abstrakt innerhalb der Simulation. Unterstützt höhere Zweige, indem es Erkennungsrisiken in Szenario-Bewertungen reduziert.",
-];
-
+require_once __DIR__.'/includes/research.php';
 $tracks = research_get_tracks();
-echo '<section class="card table-card"><h2>Verfügbare Forschung</h2><table><thead><tr><th scope="col">Zweig</th><th scope="col">Level</th><th scope="col">Dauer</th><th scope="col">Kosten</th><th scope="col">Status</th><th scope="col">Aktion</th></tr></thead><tbody>';
+$research = [];
 foreach ($tracks as $track => $info) {
-    $cur = $info['level'];
-    $max = $info['max_level'];
-    $tooltipText = str_replace("\n", '&#10;', htmlspecialchars($trackTooltips[$track] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
-    echo '<tr><td'.($tooltipText ? ' class="tooltip" data-tooltip="'.$tooltipText.'"' : '').'><strong>'.htmlspecialchars($info['name']).'</strong></td><td>'.$cur.'/'.$max.'</td>';
-    if ($cur >= $max) {
-        echo '<td colspan="3">Max</td><td></td></tr>';
-        continue;
-    }
-    $timeStr = format_duration($info['next_time']);
-    $dep = research_check_deps($pcid, $track, $cur + 1);
-    $dep_ok = $dep === true;
-    $slotFree = ($running < $maxSlots);
-    $creditOK = $credits >= $info['next_cost'];
-    echo '<td>'.$timeStr.'</td><td>'.format_credits($info['next_cost']).'</td>';
-    echo '<td>'.dependency_badge($dep_ok).'</td>';
-    $tooltip = '';
-    if (!$dep_ok) { $tooltip = 'Abhängigkeit fehlt'; }
-    elseif (!$slotFree) { $tooltip = 'Alle Forsch-Slots belegt'; }
-    elseif (!$creditOK) { $tooltip = 'Zu wenig Credits'; }
-    $can = $dep_ok && $slotFree && $creditOK;
-    $btnAttr = 'class="btn sm start-btn" data-track="'.$track.'" data-cost="'.$info['next_cost'].'" data-duration="'.$info['next_time'].'"';
-    if (!$can) {
-        $btnAttr .= ' disabled aria-disabled="true"'.($tooltip ? ' data-tooltip="'.$tooltip.'"' : '');
-    }
-    echo '<td><button '.$btnAttr.'>Erforschen</button></td></tr>';
+    if ($info['level'] >= $info['max_level']) { continue; }
+    $research[] = [
+        'id' => $track,
+        'name' => $info['name'],
+        'level_cur' => (int)$info['level'],
+        'level_max' => (int)$info['max_level'],
+        'duration_sec' => (int)$info['next_time'],
+        'duration_text' => format_duration($info['next_time']),
+        'cost' => (int)$info['next_cost'],
+        'deps_ok' => research_check_deps($pcid, $track, $info['level'] + 1) === true
+    ];
 }
-echo '</tbody></table></section>';
 
-echo '<script>
-function updTimers(){document.querySelectorAll(".cd").forEach(function(el){var end=parseInt(el.dataset.end,10);var s=end-Math.floor(Date.now()/1000);if(s<0)s=0;var h=Math.floor(s/3600),m=Math.floor((s%3600)/60),sec=s%60;el.textContent=(h>0?String(h).padStart(2,"0")+":"+String(m).padStart(2,"0"):String(m).padStart(2,"0"))+":"+String(sec).padStart(2,"0");});}
-updTimers();setInterval(updTimers,1000);
-document.querySelectorAll(".start-btn").forEach(function(btn){btn.addEventListener("click",function(){if(btn.disabled)return;btn.disabled=true;var track=btn.dataset.track;var cost=parseInt(btn.dataset.cost,10);var old=btn.textContent;btn.innerHTML="<span class=\"spinner\"></span>";fetch("research.php?a=start&sid='.$sid.'",{method:"POST",headers:{"Content-Type":"application/x-www-form-urlencoded"},body:"track="+encodeURIComponent(track)}).then(function(r){return r.json();}).then(function(data){if(data.ok){var c=document.getElementById("kpiCredits");var nv=parseInt(c.dataset.value,10)-cost;c.dataset.value=nv;c.textContent=nv.toLocaleString("de-DE")+" Credits";btn.textContent="Gestartet";}else{btn.textContent=old;btn.disabled=false;}});});});
-document.querySelectorAll(".cancel-btn").forEach(function(btn){btn.addEventListener("click",function(){var id=btn.dataset.id;fetch("research.php?a=cancel&sid='.$sid.'",{method:"POST",headers:{"Content-Type":"application/x-www-form-urlencoded"},body:"id="+id}).then(function(r){return r.json();}).then(function(data){if(data.ok){location.reload();}});});});
-</script>';
+createlayout_top('ZeroDayEmpire - Forschung');
+?>
 
+<div class="page-head container">
+  <h1>Forschung</h1>
+  <a href="index.php" class="btn ghost sm">Zur Übersicht</a>
+</div>
+
+<div class="container strip">
+  <!-- Slots -->
+  <div class="kpi kpi-icon">
+    <div class="icon" aria-hidden="true">
+      <!-- kleines Plus-Icon -->
+      <svg viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M11 5h2v6h6v2h-6v6h-2v-6H5v-2h6z"/></svg>
+    </div>
+    <div class="stat">
+      <div class="value"><?=(int)$running?> / <?=(int)$maxSlots?> <span class="unit">Slots</span></div>
+      <div class="progress" aria-label="Forschungsslot-Auslastung">
+        <div class="bar" style="width: <?=max(0,min(100, ($maxSlots>0? ($running/$maxSlots)*100 : 0)))?>%"></div>
+      </div>
+      <div class="label">Laufend / Gesamt</div>
+    </div>
+  </div>
+
+  <!-- Credits -->
+  <div class="kpi kpi-icon">
+    <div class="icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M3 5h18v14H3zM5 9h14v2H5z"/></svg>
+    </div>
+    <div class="stat">
+      <div class="value"><?=number_format($credits, 0, ',', '.') ?> <span class="unit">Credits</span></div>
+      <div class="label">Verfügbar</div>
+    </div>
+  </div>
+
+  <!-- Warteschlange / Status -->
+  <div class="kpi kpi-icon">
+    <div class="icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M12 7v5l4 2-.7 1.3L11 13V7zM12 2a10 10 0 100 20 10 10 0 000-20z"/></svg>
+    </div>
+    <div class="stat">
+      <?php if($running > 0): ?>
+        <div class="value"><span id="eta">Berechnung…</span></div>
+        <div class="label">Nächste Fertigstellung</div>
+      <?php else: ?>
+        <div class="value">Keine Forschung aktiv</div>
+        <div class="label">Warteschlange</div>
+      <?php endif; ?>
+    </div>
+  </div>
+</div>
+
+<?php if($running > 0): ?>
+<div class="container card list" style="margin-top:8px">
+  <h2>Laufende Forschung</h2>
+  <ul class="list">
+    <?php foreach($activeResearch as $r): ?>
+      <li class="list-row">
+        <span class="name"><?=htmlspecialchars($r['name'])?> (Level <?= (int)$r['level']?>)</span>
+        <span class="muted" id="eta-<?= (int)$r['id']?>"><?=htmlspecialchars($r['eta_text'])?></span>
+        <button class="button cancel-research" data-id="<?= (int)$r['id']?>">Abbrechen</button>
+      </li>
+    <?php endforeach; ?>
+  </ul>
+</div>
+<?php endif; ?>
+
+<div class="container card table-card">
+  <h2>Verfügbare Forschung</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Zweig</th>
+        <th>Level</th>
+        <th>Dauer</th>
+        <th>Kosten</th>
+        <th>Status</th>
+        <th class="number">Aktion</th>
+      </tr>
+    </thead>
+    <tbody>
+      <?php foreach($research as $row):
+        $depsOk = !empty($row['deps_ok']);
+        $enoughCredits = ($credits >= $row['cost']);
+        $slotFree = ($running < $maxSlots);
+        $canStart = $depsOk && $enoughCredits && $slotFree;
+      ?>
+      <tr>
+        <td class="name"><?=htmlspecialchars($row['name'])?></td>
+        <td><?= (int)$row['level_cur']?>/<?= (int)$row['level_max']?></td>
+        <td><?=htmlspecialchars($row['duration_text'])?></td>
+        <td class="number"><?=number_format($row['cost'], 0, ',', '.') ?> Credits</td>
+
+        <td>
+          <?php if($depsOk): ?>
+            <span class="badge ok">Erfüllte Abhängigkeit</span>
+          <?php else: ?>
+            <span class="badge fail">Abhängigkeit fehlt</span>
+          <?php endif; ?>
+        </td>
+
+        <td class="number">
+          <button
+            class="button start-research"
+            <?= $canStart ? '' : 'disabled aria-disabled="true" data-tooltip="'.(
+                  !$depsOk ? 'Abhängigkeit fehlt' :
+                  (!$slotFree ? 'Alle Forsch-Slots belegt' : 'Zu wenig Credits')
+                ).'"'; ?>
+            data-id="<?=htmlspecialchars($row['id'])?>"
+            data-cost="<?= (int)$row['cost'] ?>"
+            data-duration="<?= (int)$row['duration_sec'] ?>"
+          >Erforschen</button>
+        </td>
+      </tr>
+      <?php endforeach; ?>
+    </tbody>
+  </table>
+</div>
+
+<script>
+  // Beispiel: Countdown für KPI-„eta“
+  <?php if(!empty($nextEtaTs)): ?>
+  (function(){
+    const el = document.getElementById('eta');
+    const end = <?= (int)$nextEtaTs ?> * 1000;
+    function tick(){
+      const t = Math.max(0, end - Date.now());
+      const h = Math.floor(t/3600000), m = Math.floor((t%3600000)/60000);
+      el.textContent = (h? h+' h ' : '') + m + ' min';
+      if(t>0) requestAnimationFrame(tick);
+    }
+    tick();
+  })();
+  <?php endif; ?>
+
+  // „Erforschen“ mit Inline-Spinner und Kontrast sicher
+  document.querySelectorAll('.start-research').forEach(btn=>{
+    btn.addEventListener('click', async ()=>{
+      if(btn.disabled) return;
+      const label = btn.textContent;
+      btn.innerHTML = '<span class="spinner" aria-hidden="true"></span>';
+      try{
+        const res = await fetch('research.php?a=start', {
+          method:'POST',
+          headers:{'Content-Type':'application/x-www-form-urlencoded'},
+          body: new URLSearchParams({ track: btn.dataset.id })
+        }).then(r=>r.json());
+        if(res.ok){ location.reload(); }
+        else{
+          btn.textContent = label;
+          btn.setAttribute('data-tooltip',
+            res.reason==='credits' ? 'Zu wenig Credits' :
+            res.reason==='slots'   ? 'Alle Forsch-Slots belegt' :
+            'Abhängigkeit fehlt'
+          );
+        }
+      }catch(e){ btn.textContent = label; }
+    });
+  });
+
+  document.querySelectorAll('.cancel-research').forEach(btn=>{
+    btn.addEventListener('click', async ()=>{
+      const id = btn.dataset.id;
+      btn.disabled = true;
+      try{
+        const res = await fetch('research.php?a=cancel', {
+          method:'POST',
+          headers:{'Content-Type':'application/x-www-form-urlencoded'},
+          body: new URLSearchParams({ id })
+        }).then(r=>r.json());
+        if(res.ok){ location.reload(); }
+        else{ btn.disabled = false; }
+      }catch(e){ btn.disabled=false; }
+    });
+  });
+</script>
+
+<?php
 createlayout_bottom();
 ?>

--- a/style.css
+++ b/style.css
@@ -288,3 +288,35 @@ pre, code{ background: var(--bg-2); border:1px solid var(--border); border-radiu
 @keyframes spin{to{transform:rotate(360deg);}}
 @media(max-width:1024px){.strip{grid-template-columns:repeat(2,1fr);}}
 @media(max-width:640px){.strip{grid-template-columns:1fr;}}
+/* Research fine-tuning */
+.strip { margin: 24px 0 24px; gap: 14px; }
+.kpi { min-height: 88px; }
+.kpi .icon { width: 24px; height: 24px; }
+.kpi .value { line-height: 1.1; }
+
+.badge.fail{
+  background: rgba(255,71,87,.10);
+  color: #ff4757;
+  border: 1px solid rgba(255,71,87,.45);
+}
+
+/* Lesbarer Hover für Aktions-Buttons in legacy .content */
+.content .button,
+.content button,
+.content input[type="submit"]{
+  color:#fff;
+}
+.content .button:hover,
+.content button:hover,
+.content input[type="submit"]:hover{
+  color:#fff;
+  filter: saturate(1.1) brightness(1.05);
+}
+
+/* Tabelle flexibel */
+.table-card{ margin-top: 24px; overflow:auto; }
+.table-card table{ width:100%; table-layout:auto; }
+.table-card th,.table-card td{ white-space:nowrap; }
+@media (max-width: 900px){
+  .table-card th,.table-card td{ white-space:normal; }
+}


### PR DESCRIPTION
## Summary
- Unify research page header and KPI cards with small icons and queue status
- Add optional running research list and responsive table with dependency badges
- Enhance CSS for readable buttons, badges, and flexible table layout

## Testing
- `php -l research.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5413f7d088325b286727c73ff32f3