### PR TITLE
Verbesserte Forschungstabelle und Tooltips

### DIFF
--- a/research.php
+++ b/research.php
@@ -48,9 +48,7 @@ function format_credits($n) {
     return number_format((int)$n, 0, ',', '.').' Credits';
 }
 function dependency_badge($ok) {
-    return $ok
-        ? '<span class="badge ok">Erfüllte Abhängigkeit</span>'
-        : '<span class="badge muted">Abhängigkeit fehlt</span>';
+    return '<span class="badge muted">'.($ok ? 'Erfüllte Abhängigkeit' : 'Abhängigkeit fehlt').'</span>';
 }
 
 createlayout_top('ZeroDayEmpire - Forschung');
@@ -119,10 +117,13 @@ foreach ($tracks as $track => $info) {
     $slotFree = ($running < $maxSlots);
     $creditOK = $credits >= $info['next_cost'];
     echo '<td>'.$timeStr.'</td><td>'.format_credits($info['next_cost']).'</td>';
-    echo '<td>'.dependency_badge($dep_ok).'</td>';
+    $depTooltip = '';
+    if (!$dep_ok) {
+        $depTooltip = str_replace("\n", '&#10;', htmlspecialchars("Abhängigkeit fehlt:\n".$dep, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+    }
+    echo '<td'.($depTooltip ? ' class="tooltip" data-tooltip="'.$depTooltip.'"' : '').'>'.dependency_badge($dep_ok).'</td>';
     $tooltip = '';
-    if (!$dep_ok) { $tooltip = 'Abhängigkeit fehlt'; }
-    elseif (!$slotFree) { $tooltip = 'Alle Forsch-Slots belegt'; }
+    if (!$slotFree) { $tooltip = 'Alle Forsch-Slots belegt'; }
     elseif (!$creditOK) { $tooltip = 'Zu wenig Credits'; }
     $can = $dep_ok && $slotFree && $creditOK;
     $btnAttr = 'class="btn sm start-btn" data-track="'.$track.'" data-cost="'.$info['next_cost'].'" data-duration="'.$info['next_time'].'"';

--- a/style.css
+++ b/style.css
@@ -265,12 +265,11 @@ pre, code{ background: var(--bg-2); border:1px solid var(--border); border-radiu
 .page-head{display:flex;align-items:center;justify-content:space-between;margin:24px 0 18px;}
 .page-head h1{margin:0;}
 .kpi-icon{justify-content:flex-start;gap:12px;}
-.kpi-icon .icon{width:24px;height:24px;}
+.kpi-icon .icon{width:12px;height:12px;}
 .kpi-icon .stat{flex:1;}
 .kpi-icon .label{color:var(--muted);font-size:13px;margin-top:2px;}
 .kpi-icon .progress{margin-top:6px;}
 .badge{display:inline-block;padding:4px 6px;border-radius:8px;font-size:12px;}
-.badge.ok{background:rgba(0,210,120,.1);color:#00d278;border:1px solid rgba(0,210,120,.4);}
 .badge.muted{background:rgba(255,255,255,.05);color:var(--muted);border:1px solid var(--border);}
 .card.list{padding:0;}
 .card.list h2{padding:18px 18px 0;margin:0;}
@@ -278,7 +277,7 @@ pre, code{ background: var(--bg-2); border:1px solid var(--border); border-radiu
 .list-row{display:flex;align-items:center;gap:12px;padding:12px 18px;border-top:1px solid var(--border);}
 .list-row:first-child{border-top:none;}
 .list-row .name{flex:1;font-weight:600;}
-.table-card{margin-top:36px;overflow:auto;}
+.table-card{margin-top:36px;overflow:auto;grid-column:1/-1;}
 .table-card table{width:100%;border-collapse:collapse;}
 .table-card thead th{position:sticky;top:0;background:rgba(255,255,255,.03);text-align:left;}
 .table-card tbody tr:nth-child(even){background:rgba(255,255,255,.02);}


### PR DESCRIPTION
## Summary
- Verkleinere KPI-Icons um 50%
- Entferne Rahmenfarbe der Abhängigkeits-Badge und nutze Tooltip mit fehlender Abhängigkeit
- Tabelle nutzt nun die komplette Breite

## Testing
- `php -l research.php`
- `php -l includes/research.php`


------
https://chatgpt.com/codex/tasks/task_b_68c543a1f5808325ba0b0550a93c2277