### PR TITLE
Refine research tooltip, icon sizing, and table layout

### DIFF
--- a/research.php
+++ b/research.php
@@ -119,7 +119,7 @@ foreach ($tracks as $track => $info) {
     echo '<td>'.$timeStr.'</td><td>'.format_credits($info['next_cost']).'</td>';
     $depTooltip = '';
     if (!$dep_ok) {
-        $depTooltip = str_replace("\n", '&#10;', htmlspecialchars("Abhängigkeit fehlt:\n".$dep, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+        $depTooltip = str_replace("\n", '&#10;', htmlspecialchars($dep, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
     }
     echo '<td'.($depTooltip ? ' class="tooltip" data-tooltip="'.$depTooltip.'"' : '').'>'.dependency_badge($dep_ok).'</td>';
     $tooltip = '';

--- a/style.css
+++ b/style.css
@@ -265,7 +265,7 @@ pre, code{ background: var(--bg-2); border:1px solid var(--border); border-radiu
 .page-head{display:flex;align-items:center;justify-content:space-between;margin:24px 0 18px;}
 .page-head h1{margin:0;}
 .kpi-icon{justify-content:flex-start;gap:12px;}
-.kpi-icon .icon{width:12px;height:12px;}
+.kpi-icon .icon{width:6px;height:6px;}
 .kpi-icon .stat{flex:1;}
 .kpi-icon .label{color:var(--muted);font-size:13px;margin-top:2px;}
 .kpi-icon .progress{margin-top:6px;}
@@ -277,8 +277,8 @@ pre, code{ background: var(--bg-2); border:1px solid var(--border); border-radiu
 .list-row{display:flex;align-items:center;gap:12px;padding:12px 18px;border-top:1px solid var(--border);}
 .list-row:first-child{border-top:none;}
 .list-row .name{flex:1;font-weight:600;}
-.table-card{margin-top:36px;overflow:auto;grid-column:1/-1;}
-.table-card table{width:100%;border-collapse:collapse;}
+.table-card{margin-top:36px;overflow:auto;grid-column:1/-1;width:100%;}
+.table-card table{width:100%;border-collapse:collapse;table-layout:auto;}
 .table-card thead th{position:sticky;top:0;background:rgba(255,255,255,.03);text-align:left;}
 .table-card tbody tr:nth-child(even){background:rgba(255,255,255,.02);}
 .table-card th, .table-card td{padding:10px 12px;border-bottom:1px dashed var(--border);}


### PR DESCRIPTION
## Summary
- Remove redundant "Abhängigkeit fehlt" label from missing dependency tooltip
- Shrink KPI icons by roughly 50% for a cleaner header
- Allow research table to expand dynamically with full-width layout

## Testing
- `php -l research.php`

------
https://chatgpt.com/codex/tasks/task_b_68c5473ce4088325a4e46c647c747e23