### PR TITLE
Show Operation Center dependency message

### DIFF
--- a/battle.php
+++ b/battle.php
@@ -23,7 +23,7 @@ if ($action == '') {
 }
 
 if ($pc['mk'] < 1) {
-    no_();
+    simple_message('Dieses Menü steht dir noch nicht zur Verfügung.<br />Du benötigst ein <a href="game.php?m=item&amp;item=mk&amp;sid='.$sid.'">Malware Kit</a>.', 'info');
     exit;
 }
 if ($pc['blocked'] > time()) {


### PR DESCRIPTION
## Summary
- Tell players that Operation Center requires a Malware Kit when they lack one

## Testing
- `php -l battle.php`


------
https://chatgpt.com/codex/tasks/task_b_68c558465dcc83259cc883b2c97c7941