### PR TITLE
Improve research overview and tooltips

### DIFF
--- a/research.php
+++ b/research.php
@@ -72,13 +72,14 @@ if ($running) {
     $maxLvl = $info['max_level'] ?? $first['target_level'];
     $progress = $curLvl.'/'.$maxLvl;
     $queueTime = $first['end'] - $now;
-    $queueLabel = $progress.' <span class="cd" data-end="'.$first['end'].'">'.sprintf('%02d:%02d', floor($queueTime/3600), floor(($queueTime%3600)/60)).'</span> min';
+    $name = htmlspecialchars($info['name'] ?? $first['track']);
+    $queueLabel = $name.' '.$progress.' <span class="cd" data-end="'.$first['end'].'">'.sprintf('%02d:%02d', floor($queueTime/3600), floor(($queueTime%3600)/60)).'</span> min';
 }
 
 echo '<div class="strip">';
-echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><path d="M3 12h18M12 3v18" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><h3 class="value">Verfügbare Slots: '.$running.' / '.$maxSlots.'</h3></div></div>';
-echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><path d="M4 4h16v12H4z" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M2 18h20" stroke="rgb(var(--accent))"/></svg><div class="stat"><h3 class="value" id="kpiCredits" data-value="'.$credits.'">'.format_credits($credits).'</h3></div></div>';
-echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><circle cx="12" cy="12" r="9" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M12 7v5l3 2" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><h3 class="value">'.$queueLabel.'</h3></div></div>';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><path d="M3 12h18M12 3v18" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><h3 class="value small">Verfügbare Slots: '.$running.' / '.$maxSlots.'</h3></div></div>';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><path d="M4 4h16v12H4z" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M2 18h20" stroke="rgb(var(--accent))"/></svg><div class="stat"><h3 class="value small" id="kpiCredits" data-value="'.$credits.'">'.format_credits($credits).'</h3></div></div>';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><circle cx="12" cy="12" r="9" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M12 7v5l3 2" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><h3 class="value small">'.$queueLabel.'</h3></div></div>';
 echo '</div>';
 
 $trackTooltips = [
@@ -122,10 +123,13 @@ foreach ($tracks as $track => $info) {
     $btnAttr = 'class="btn sm start-btn" data-track="'.$track.'" data-cost="'.$info['next_cost'].'" data-duration="'.$info['next_time'].'"';
     if (!$can) {
         $btnAttr .= ' disabled aria-disabled="true"';
-        if ($tooltip) { $btnAttr .= ' data-tooltip="'.$tooltip.'"'; }
         if (!$dep_ok) { $btnAttr .= ' style="background-color:#888;color:#ccc;"'; }
+        $buttonHtml = '<button '.$btnAttr.'>Erforschen</button>';
+        if ($tooltip) { $buttonHtml = '<span class="tooltip" data-tooltip="'.$tooltip.'">'.$buttonHtml.'</span>'; }
+        echo '<td>'.$buttonHtml.'</td></tr>';
+    } else {
+        echo '<td><button '.$btnAttr.'>Erforschen</button></td></tr>';
     }
-    echo '<td><button '.$btnAttr.'>Erforschen</button></td></tr>';
 }
 echo '</tbody></table></section>';
 

--- a/style.css
+++ b/style.css
@@ -68,6 +68,7 @@ a{color:inherit; text-decoration:none}
 .kpi{ background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.01)); border:1px solid var(--border); padding:16px; border-radius:var(--radius); display:flex; align-items:center; justify-content:space-between }
 .kpi .label{ color:var(--muted); font-size:13px }
 .kpi .value{ font-weight:800; font-size:clamp(18px,3vw,28px) }
+.kpi .value.small{ font-size:16px; font-weight:800; }
 .kpi .value .unit{ font-weight:400; font-size:clamp(12px,2vw,16px) }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- Show active research name and progress in progress box
- Shrink KPI headline text to match table row size
- Make disabled research buttons use same tooltip style as status column

## Testing
- `php -l research.php`

------
https://chatgpt.com/codex/tasks/task_b_68c55957ec1c832583515e0b5453df4d