### PR TITLE
Redesign upgradelist to match research style

### DIFF
--- a/upgradelist.php
+++ b/upgradelist.php
@@ -27,108 +27,104 @@ if ($pc['blocked'] > time()) {
     exit;
 }
 
+function format_duration($seconds)
+{
+    $seconds = (int)$seconds;
+    $h = floor($seconds / 3600);
+    $m = floor(($seconds % 3600) / 60);
+    if ($h > 0) {
+        return $m > 0 ? $h.' h '.$m.' min' : $h.' h';
+    }
+    return $m.' min';
+}
+function format_credits($n)
+{
+    return number_format((int)$n, 0, ',', '.').' Credits';
+}
+function dependency_badge($ok)
+{
+    return '<span class="badge muted">'.($ok ? 'Erf&uuml;llte Abh&auml;ngigkeit' : 'Abh&auml;ngigkeit fehlt').'</span>';
+}
+
 createlayout_top('ZeroDayEmpire - Dein Computer');
-?>
-<!-- ZDE theme inject -->
-<style>@import url("style.css");</style>
-<div class="container">
-<?php // /ZDE theme inject start
 
-echo '<div class="content" id="computer">' . "\n";
-echo '<h2>Dein Computer</h2>' . "\n";
-echo '<div class="submenu"><p><a href="game.php?m=start&amp;sid='.$sid.'">Zur &Uuml;bersicht</a></p></div>' . "\n";
-echo '<div id="computer-upgrades">' . "\n";
-echo $notif;
+echo '<header class="page-head"><h1>Dein Computer</h1><a href="game.php?m=start&amp;sid='.$sid.'" class="btn ghost sm">Zur &Uuml;bersicht</a></header>';
 
-$r = db_query('SELECT * FROM `upgrades` WHERE `pc`=\''.mysql_escape_string($pcid).'\' AND `end`>\''.time().'\' ORDER BY `start` ASC;');
-$full = @mysql_num_rows($r);
-if ($full > 0) {
+$now = time();
+$runningRows = [];
+$r = db_query('SELECT * FROM `upgrades` WHERE `pc`=\''.mysql_escape_string($pcid).'\' AND `end`>\''.mysql_escape_string($now).'\' ORDER BY `start` ASC');
+while ($row = mysql_fetch_assoc($r)) { $runningRows[] = $row; }
+$running = count($runningRows);
+$credits = (int)$pc['credits'];
+
+$queueLabel = 'Kein Upgrade aktiv';
+if ($running) {
     $tmppc = $pc;
-    echo '<h3>Upgrade-Queue</h3><p><strong>Es sind '.$full.' von '.UPGRADE_QUEUE_LENGTH.' Slots belegt</strong></p>' . "\n";
-    echo '<table>' . "\n";
-    while ($data = mysql_fetch_assoc($r)) {
-        $item = $data['item'];
+    $first = $runningRows[0];
+    $item = $first['item'];
+    $newlv = itemnextlevel($item, $tmppc[$item]);
+    $s1 = formatitemlevel($item, $tmppc[$item]);
+    $s2 = formatitemlevel($item, $newlv);
+    $timeLeft = $first['end'] - $now;
+    $queueLabel = idtoname($item).' '.$s1.' &raquo; '.$s2.' <span class="cd" data-end="'.$first['end'].'">'.sprintf('%02d:%02d', floor($timeLeft/3600), floor(($timeLeft%3600)/60)).'</span> min';
+}
+
+echo '<div class="strip">';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><path d="M3 12h18M12 3v18" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><h3 class="value small">Verf&uuml;gbare Slots: '.$running.' / '.UPGRADE_QUEUE_LENGTH.'</h3></div></div>';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><path d="M4 4h16v12H4z" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M2 18h20" stroke="rgb(var(--accent))"/></svg><div class="stat"><h3 class="value small" id="kpiCredits" data-value="'.$credits.'">'.format_credits($credits).'</h3></div></div>';
+echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true" width="50" height="50"><circle cx="12" cy="12" r="9" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/><path d="M12 7v5l3 2" stroke="rgb(var(--accent))" stroke-width="2" fill="none"/></svg><div class="stat"><h3 class="value small">'.$queueLabel.'</h3></div></div>';
+echo '</div>';
+
+if ($running) {
+    echo '<section class="card table-card"><h2>Upgrade-Queue</h2><table style="width:100%"><thead><tr><th>Item</th><th>Level</th><th>Fertig in</th><th>Aktion</th></tr></thead><tbody>';
+    $tmppc = $pc;
+    foreach ($runningRows as $row) {
+        $item = $row['item'];
         $newlv = itemnextlevel($item, $tmppc[$item]);
         $s1 = formatitemlevel($item, $tmppc[$item]);
         $s2 = formatitemlevel($item, $newlv);
-        echo '<tr><th>'.idtoname($item).'</th><td>'.$s1.' &raquo; '.$s2.'</td>';
-        echo '<td>'.nicetime($data['end']).'</td>';
-        echo '<td><a href="game.php?page=cancelupgrade&amp;upgrade='.$data['id'].'&amp;sid='.$sid.'">Abbrechen</a></td></tr>' . "\n";
+        echo '<tr><td>'.idtoname($item).'</td><td>'.$s1.' &raquo; '.$s2.'</td><td><span class="cd" data-end="'.$row['end'].'"></span></td><td><a class="btn sm" href="game.php?page=cancelupgrade&amp;upgrade='.$row['id'].'&amp;sid='.$sid.'">Abbrechen</a></td></tr>';
         $tmppc[$item] = $newlv;
     }
-    echo '</table>' . "\n";
-    echo '<p>Wichtig: Das Geld von einem abgebrochenen Upgrade wird NICHT zur&uuml;ckerstattet, sondern ist verloren!</p>';
+    echo '</tbody></table><p>Wichtig: Das Geld von einem abgebrochenen Upgrade wird NICHT zur&uuml;ckerstattet, sondern ist verloren!</p></section>';
 }
 
-if ($full < UPGRADE_QUEUE_LENGTH) {
-    if (isset($tmppc)) {
-        $pc = $tmppc;
-    }
-    echo '<h3>Upgrade zur Queue hinzuf&uuml;gen</h3>';
-    echo '<p><strong>Geld: '.$bucks.' Credits</strong></p>' . "\n";
-    $SALT = file_get('data/upgr_SALT.dat');
-    $idparam = preg_replace('([./])', '', crypt('ZDEiTeM', $SALT));
-    function buildinfo($id)
-    {
-        global $STYLESHEET, $DATADIR, $pc, $bucks, $sid, $usrid, $pcid;
-        global $r, $full, $SALT, $idparam;
-        if (isavailb($id, $pc)) {
-            $inf = getiteminfo($id, $pc[$id]);
-            $m = intval($inf['d']);
-            $xm = $m;
-            if ($m >= 60) {
-                $m = floor($m / 60).' h';
-                if (floor($xm % 60) > 0) {
-                    $m .= ' : '.floor($xm % 60).' min';
-                }
-            } else {
-                $m .= ' min';
-            }
-            $xm *= 60;
-            $lastend = ($full < 1 ? time() : mysql_result($r, $full - 1, 'end'));
-            $xm += $lastend;
-            $m .= '</td><td>'.nicetime2($xm, false, ' um ', ' Uhr');
-            $name = idtoname($id);
-            $val = $pc[$id];
-            $sval = formatitemlevel($id, $val);
-            $s = $name.' ('.$sval.')';
-            echo '<tr>'.LF.'<td>';
-            echo $s;
-            echo '</td>' . "\n";
-            echo '<td>'.$m.'</td><td>'.$inf['c'].' Credits</td>';
-            echo '<td>';
-            $encrid = crypt($id, $SALT);
-            if ($pc['credits'] >= $inf['c']) {
-                echo '<a href="game.php?m=upgrade&amp;'.$idparam.'='.$encrid.'&amp;sid='.$sid.'" class="buy">';
-                if ($pc[$id] > 0 || $id == 'ram' || $id == 'cpu') {
-                    $s = 'Upgrade kaufen';
-                } else {
-                    $s = 'Kaufen';
-                }
-                echo $s.'</a>';
-            } else {
-                echo 'Nicht gen&uuml;gend Geld';
-            }
-            echo '</td></tr>';
-            return true;
-        }
-        return false;
-    }
-    echo '<table>' . "\n";
-    echo '<tr>'.LF.'<th>Item</th>'.LF.'<th>Dauer</th>'.LF.'<th>Fertigstellung</th>'.LF.'<th>Kosten</th>'.LF.'<th>Upgrade</th>'.LF.'</tr>' . "\n";
-    reset($items);
-    $cnt = 0;
-    foreach ($items as $dummy => $item) {
-        if (buildinfo($item)) {
-            $cnt++;
-        }
-    }
-    echo '</table>';
-}
+$SALT = file_get('data/upgr_SALT.dat');
+$idparam = preg_replace('([./])', '', crypt('ZDEiTeM', $SALT));
 
-echo "\n".'</div>'.LF.'</div>'."\n";
-?>
-</div>
-<!-- /ZDE theme inject -->
-<?php
+echo '<section class="card table-card" id="upgradeTable" style="overflow:visible"><h2>Verf&uuml;gbare Upgrades</h2><table style="width:100%"><thead><tr><th scope="col" style="text-align:center">Item</th><th scope="col" style="text-align:center">Level</th><th scope="col" style="text-align:center">Dauer</th><th scope="col" style="text-align:center">Kosten</th><th scope="col" style="text-align:center">Status</th><th scope="col" style="text-align:center">Aktion</th></tr></thead><tbody>';
+foreach ($items as $item) {
+    $cur = $pc[$item];
+    $max = itemmaxval($item);
+    $curStr = formatitemlevel($item, $cur);
+    $maxStr = formatitemlevel($item, $max);
+    echo '<tr><td><strong>'.idtoname($item).'</strong></td><td>'.$curStr.' / '.$maxStr.'</td>';
+    if ($cur >= $max) {
+        echo '<td colspan="3">Max</td><td></td></tr>';
+        continue;
+    }
+    $inf = getiteminfo($item, $cur);
+    $timeStr = format_duration($inf['d'] * 60);
+    $dep_ok = isavailb($item, $pc);
+    $slotFree = ($running < UPGRADE_QUEUE_LENGTH);
+    $creditOK = ($credits >= $inf['c']);
+    echo '<td>'.$timeStr.'</td><td>'.format_credits($inf['c']).'</td>';
+    echo '<td>'.dependency_badge($dep_ok).'</td>';
+    $can = $dep_ok && $slotFree && $creditOK;
+    $encrid = crypt($item, $SALT);
+    if ($can) {
+        echo '<td><a class="btn sm" href="game.php?m=upgrade&amp;'.$idparam.'='.$encrid.'&amp;sid='.$sid.'">Upgrade</a></td></tr>';
+    } else {
+        $tooltip = '';
+        if (!$slotFree) { $tooltip = 'Alle Upgrade-Slots belegt'; }
+        elseif (!$creditOK) { $tooltip = 'Zu wenig Credits'; }
+        $btnHtml = '<span class="btn sm" style="background-color:#888;color:#ccc;" aria-disabled="true">Upgrade</span>';
+        if ($tooltip) { $btnHtml = '<span class="tooltip" data-tooltip="'.$tooltip.'">'.$btnHtml.'</span>'; }
+        echo '<td>'.$btnHtml.'</td></tr>';
+    }
+}
+echo '</tbody></table></section>';
+
+echo '<script>function updTimers(){document.querySelectorAll(".cd").forEach(function(el){var end=parseInt(el.dataset.end,10);if(!end)return;var s=end-Math.floor(Date.now()/1000);if(s<0)s=0;var h=Math.floor(s/3600),m=Math.floor((s%3600)/60),sec=s%60;el.textContent=(h>0?String(h).padStart(2,"0")+":"+String(m).padStart(2,"0"):String(m).padStart(2,"0"))+":"+String(sec).padStart(2,"0");});}updTimers();setInterval(updTimers,1000);</script>';
+
 createlayout_bottom();


### PR DESCRIPTION
## Summary
- Rework `upgradelist.php` with modern layout matching `research.php`
- Display upgrade slots, credits, and active queue in KPI strip
- List all upgradeable items with dependency badges and action buttons

## Testing
- `php -l upgradelist.php`


------
https://chatgpt.com/codex/tasks/task_b_68c55ac3a0248325ab12ee872150e15f