### PR TITLE
Remove scrollbars from Upgrade-Queue table

### DIFF
--- a/upgradelist.php
+++ b/upgradelist.php
@@ -76,7 +76,7 @@ echo '<div class="kpi kpi-icon"><svg class="icon" viewBox="0 0 24 24" aria-hidde
 echo '</div>';
 
 if ($running) {
-    echo '<section class="card table-card"><h2>Upgrade-Queue</h2><table style="width:100%"><thead><tr><th>Item</th><th>Level</th><th>Fertig in</th><th>Aktion</th></tr></thead><tbody>';
+    echo '<section class="card table-card" style="overflow:visible"><h2>Upgrade-Queue</h2><table style="width:100%"><thead><tr><th>Item</th><th>Level</th><th>Fertig in</th><th>Aktion</th></tr></thead><tbody>';
     $tmppc = $pc;
     foreach ($runningRows as $row) {
         $item = $row['item'];


### PR DESCRIPTION
## Summary
- ensure Upgrade-Queue table never shows scrollbars by overriding overflow behavior

## Testing
- `php -l upgradelist.php`


------
https://chatgpt.com/codex/tasks/task_b_68c55cdcd6988325881ac7f21e7aa99f