### PR TITLE
Preserve session on legal pages and fix title

### DIFF
--- a/impressum.php
+++ b/impressum.php
@@ -49,16 +49,28 @@
   </footer>
   <script>
     (function(){
-      let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
-      if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
-        localStorage.setItem('token', token);
-      }
-      const role = localStorage.getItem('role') || sessionStorage.getItem('role');
+      const params = new URLSearchParams(location.search);
+      const sid = params.get('sid');
       const reg = document.getElementById('registerLink');
       const dash = document.getElementById('dashboardLink');
       const logout = document.getElementById('logoutLink');
       const cfg = document.getElementById('configLink');
       const playLinks = document.querySelectorAll('.play-link');
+      if(sid){
+        const brand = document.querySelector('.brand');
+        if(brand) brand.href = 'game.php?m=start&sid=' + sid;
+        if(reg) reg.style.display='none';
+        if(dash){ dash.style.display='inline-flex'; dash.href='game.php?m=start&sid='+sid; }
+        if(logout){ logout.style.display='inline-flex'; logout.href='login.php?a=logout&sid='+sid; logout.removeAttribute('onclick'); }
+        playLinks.forEach(a => a.href='game.php?m=start&sid='+sid);
+        document.querySelectorAll('footer .links a').forEach(a => { a.href = a.getAttribute('href') + '?sid=' + sid; });
+        return;
+      }
+      let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
+      if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
+        localStorage.setItem('token', token);
+      }
+      const role = localStorage.getItem('role') || sessionStorage.getItem('role');
       window.logout = function(){
         localStorage.removeItem('token');
         localStorage.removeItem('role');

--- a/layout.php
+++ b/layout.php
@@ -88,10 +88,15 @@ function createlayout_top($title = 'ZeroDayEmpire', $nomenu = false)
 
 function createlayout_bottom()
 {
+    global $usr;
+    $sid = '';
+    if (isset($usr['sid']) && $usr['sid'] !== '') {
+        $sid = '?sid=' . $usr['sid'];
+    }
     echo "</main>\n";
     echo '<footer><div class="container foot">';
     echo '<div>© <span id="year"></span> ZeroDayEmpire</div>';
-    echo '<div class="links"><a href="impressum.php">Impressum</a><a href="legal.php">Legal</a><a href="rules.php">Spielregeln</a></div>';
+    echo '<div class="links"><a href="impressum.php' . $sid . '">Impressum</a><a href="legal.php' . $sid . '">Legal</a><a href="rules.php' . $sid . '">Spielregeln</a></div>';
     echo '</div></footer>';
     echo '<script>(function(){const nav=document.getElementById("nav");const btn=document.getElementById("menuBtn");if(btn){btn.addEventListener("click",()=>{const open=nav.classList.toggle("open");btn.setAttribute("aria-expanded",String(open));});}})();';
     echo 'window.addEventListener("pointermove",e=>{const x=e.clientX/window.innerWidth*100;const y=e.clientY/window.innerHeight*100;document.documentElement.style.setProperty("--mx",x+"%");document.documentElement.style.setProperty("--my",y+"%");},{passive:true});';

--- a/legal.php
+++ b/legal.php
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Legal - ZeroDayEmpire</title>
+  <title>ZeroDayEmpire - Legal</title>
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='%2300ffc3' d='M50 5L95 50 50 95 5 50z'/%3E%3C/svg%3E"/>
   <link rel="stylesheet" href="style.css" />
 </head>
@@ -52,16 +52,28 @@
   </footer>
   <script>
     (function(){
-      let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
-      if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
-        localStorage.setItem('token', token);
-      }
-      const role = localStorage.getItem('role') || sessionStorage.getItem('role');
+      const params = new URLSearchParams(location.search);
+      const sid = params.get('sid');
       const reg = document.getElementById('registerLink');
       const dash = document.getElementById('dashboardLink');
       const logout = document.getElementById('logoutLink');
       const cfg = document.getElementById('configLink');
       const playLinks = document.querySelectorAll('.play-link');
+      if(sid){
+        const brand = document.querySelector('.brand');
+        if(brand) brand.href = 'game.php?m=start&sid=' + sid;
+        if(reg) reg.style.display='none';
+        if(dash){ dash.style.display='inline-flex'; dash.href='game.php?m=start&sid='+sid; }
+        if(logout){ logout.style.display='inline-flex'; logout.href='login.php?a=logout&sid='+sid; logout.removeAttribute('onclick'); }
+        playLinks.forEach(a => a.href='game.php?m=start&sid='+sid);
+        document.querySelectorAll('footer .links a').forEach(a => { a.href = a.getAttribute('href') + '?sid=' + sid; });
+        return;
+      }
+      let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
+      if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
+        localStorage.setItem('token', token);
+      }
+      const role = localStorage.getItem('role') || sessionStorage.getItem('role');
       window.logout = function(){
         localStorage.removeItem('token');
         localStorage.removeItem('role');


### PR DESCRIPTION
## Summary
- Keep session id in footer links so navigation to legal pages doesn't drop the login
- Allow impressum and legal pages to carry session id through their nav links
- Correct the page title order on `legal.php`

## Testing
- `php -l layout.php`
- `php -l legal.php`
- `php -l impressum.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5649e271c8325a84b5565d557cafe