### PR TITLE
Keep in-game menu on legal pages when user is logged in

### DIFF
--- a/impressum.php
+++ b/impressum.php
@@ -1,105 +1,23 @@
-<!DOCTYPE html>
-<html lang="de">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Impressum - ZeroDayEmpire</title>
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='%2300ffc3' d='M50 5L95 50 50 95 5 50z'/%3E%3C/svg%3E"/>
-  <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-  <header class="site-header">
-    <div class="container nav" id="nav">
-      <a class="brand" href="index.php" aria-label="ZeroDayEmpire Startseite">
-        <svg viewBox="0 0 100 100" aria-hidden="true" role="img">
-          <path d="M50 5L95 50 50 95 5 50z" fill="rgb(var(--accent))"/>
-          <path d="M50 20 80 50 50 80 20 50z" fill="#0b0f14"/>
-        </svg>
-        <div class="title">ZeroDayEmpire</div>
-        <span class="badge">Cyber-Strategie</span>
-      </a>
-      <button class="btn ghost menu-toggle" id="menuBtn" aria-expanded="false" aria-controls="navList">Menü</button>
-      <nav class="nav-links" id="navList" aria-label="Hauptnavigation">
-        <a href="pub.php?a=register" id="registerLink">Registrieren</a>
-        <a href="dashboard.html" id="dashboardLink" style="display:none">Dashboard</a>
-        <a href="#" id="logoutLink" style="display:none" onclick="logout()">Abmelden</a>
-        <a href="config.html" id="configLink" style="display:none">Config</a>
-        <a class="btn play-link" href="pub.php">Jetzt spielen</a>
-      </nav>
-    </div>
-  </header>
-  <main>
-    <div class="container">
-      <h1>Impressum</h1>
-      <p>Max Mustermann</p>
-      <p>Musterstraße 1</p>
-      <p>12345 Musterstadt</p>
-      <p>E-Mail: info@example.com</p>
-    </div>
-  </main>
-  <footer>
-    <div class="container foot">
-      <div>© <span id="year"></span> ZeroDayEmpire</div>
-      <div class="links">
-        <a href="impressum.php">Impressum</a>
-        <a href="legal.php">Legal</a>
-        <a href="rules.php">Spielregeln</a>
-      </div>
-    </div>
-  </footer>
-  <script>
-    (function(){
-      const params = new URLSearchParams(location.search);
-      const sid = params.get('sid');
-      const reg = document.getElementById('registerLink');
-      const dash = document.getElementById('dashboardLink');
-      const logout = document.getElementById('logoutLink');
-      const cfg = document.getElementById('configLink');
-      const playLinks = document.querySelectorAll('.play-link');
-      if(sid){
-        const brand = document.querySelector('.brand');
-        if(brand) brand.href = 'game.php?m=start&sid=' + sid;
-        if(reg) reg.style.display='none';
-        if(dash){ dash.style.display='inline-flex'; dash.href='game.php?m=start&sid='+sid; }
-        if(logout){ logout.style.display='inline-flex'; logout.href='login.php?a=logout&sid='+sid; logout.removeAttribute('onclick'); }
-        playLinks.forEach(a => a.href='game.php?m=start&sid='+sid);
-        document.querySelectorAll('footer .links a').forEach(a => { a.href = a.getAttribute('href') + '?sid=' + sid; });
-        return;
-      }
-      let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
-      if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
-        localStorage.setItem('token', token);
-      }
-      const role = localStorage.getItem('role') || sessionStorage.getItem('role');
-      window.logout = function(){
-        localStorage.removeItem('token');
-        localStorage.removeItem('role');
-        sessionStorage.removeItem('token');
-        sessionStorage.removeItem('role');
-        document.cookie = 'token=; Max-Age=0; path=/';
-        fetch('/logout',{method:'POST',headers:{'Authorization':token}});
-        window.location.href = 'index.php';
-      };
-      if(token){
-        if(reg) reg.style.display='none';
-        if(dash) dash.style.display='inline-flex';
-        if(logout) logout.style.display='inline-flex';
-        playLinks.forEach(a => a.href='dashboard.html');
-      }else{
-        playLinks.forEach(a => a.href='pub.php');
-      }
-      if(role === 'admin' && cfg){ cfg.style.display = 'inline-flex'; }
-    })();
-    (function(){
-      const nav = document.getElementById('nav');
-      const btn = document.getElementById('menuBtn');
-      if(!btn) return;
-      btn.addEventListener('click', () => {
-        const open = nav.classList.toggle('open');
-        btn.setAttribute('aria-expanded', String(open));
-      });
-    })();
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
-</body>
-</html>
+<?php
+// Display the Impressum page. If a valid SID is provided, keep the in-game menu.
+define('IN_ZDE', 1);
+if (isset($_GET['sid'])) {
+    // Load user context but do not require a PC to display this page.
+    $FILE_REQUIRES_PC = false;
+    include 'ingame.php';
+} else {
+    // No session id – still display the page using the public layout.
+    include 'gres.php';
+    include 'layout.php';
+}
+
+createlayout_top('Impressum - ZeroDayEmpire');
+?>
+<h1>Impressum</h1>
+<p>Max Mustermann</p>
+<p>Musterstraße 1</p>
+<p>12345 Musterstadt</p>
+<p>E-Mail: info@example.com</p>
+<?php
+createlayout_bottom();
+?>

--- a/legal.php
+++ b/legal.php
@@ -1,108 +1,24 @@
-<!DOCTYPE html>
-<html lang="de">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>ZeroDayEmpire - Legal</title>
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpath fill='%2300ffc3' d='M50 5L95 50 50 95 5 50z'/%3E%3C/svg%3E"/>
-  <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-  <header class="site-header">
-    <div class="container nav" id="nav">
-      <a class="brand" href="index.php" aria-label="ZeroDayEmpire Startseite">
-        <svg viewBox="0 0 100 100" aria-hidden="true" role="img">
-          <path d="M50 5L95 50 50 95 5 50z" fill="rgb(var(--accent))"/>
-          <path d="M50 20 80 50 50 80 20 50z" fill="#0b0f14"/>
-        </svg>
-        <div class="title">ZeroDayEmpire</div>
-        <span class="badge">Cyber-Strategie</span>
-      </a>
-      <button class="btn ghost menu-toggle" id="menuBtn" aria-expanded="false" aria-controls="navList">Menü</button>
-      <nav class="nav-links" id="navList" aria-label="Hauptnavigation">
-        <a href="pub.php?a=register" id="registerLink">Registrieren</a>
-        <a href="dashboard.html" id="dashboardLink" style="display:none">Dashboard</a>
-        <a href="#" id="logoutLink" style="display:none" onclick="logout()">Abmelden</a>
-        <a href="config.html" id="configLink" style="display:none">Config</a>
-        <a class="btn play-link" href="pub.php">Jetzt spielen</a>
-      </nav>
-    </div>
-  </header>
-  <main>
-    <div class="container">
-      <h1>Legal</h1>
-      <p>Dieses Projekt verwendet verschiedene Open‑Source‑Technologien:</p>
-      <ul>
-        <li>PHP</li>
-        <li>Nginx</li>
-        <li>MariaDB</li>
-      </ul>
-      <p>Das Originalspiel inklusive Spielmechaniken basiert auf <a href="https://github.com/dergriewatz/htn-original">HackTheNet.org</a>.</p>
-    </div>
-  </main>
-  <footer>
-    <div class="container foot">
-      <div>© <span id="year"></span> ZeroDayEmpire</div>
-      <div class="links">
-        <a href="impressum.php">Impressum</a>
-        <a href="legal.php">Legal</a>
-        <a href="rules.php">Spielregeln</a>
-      </div>
-    </div>
-  </footer>
-  <script>
-    (function(){
-      const params = new URLSearchParams(location.search);
-      const sid = params.get('sid');
-      const reg = document.getElementById('registerLink');
-      const dash = document.getElementById('dashboardLink');
-      const logout = document.getElementById('logoutLink');
-      const cfg = document.getElementById('configLink');
-      const playLinks = document.querySelectorAll('.play-link');
-      if(sid){
-        const brand = document.querySelector('.brand');
-        if(brand) brand.href = 'game.php?m=start&sid=' + sid;
-        if(reg) reg.style.display='none';
-        if(dash){ dash.style.display='inline-flex'; dash.href='game.php?m=start&sid='+sid; }
-        if(logout){ logout.style.display='inline-flex'; logout.href='login.php?a=logout&sid='+sid; logout.removeAttribute('onclick'); }
-        playLinks.forEach(a => a.href='game.php?m=start&sid='+sid);
-        document.querySelectorAll('footer .links a').forEach(a => { a.href = a.getAttribute('href') + '?sid=' + sid; });
-        return;
-      }
-      let token = localStorage.getItem('token') || sessionStorage.getItem('token') || (document.cookie.match(/token=([^;]+)/)||[])[1];
-      if(token && !localStorage.getItem('token') && !sessionStorage.getItem('token')){
-        localStorage.setItem('token', token);
-      }
-      const role = localStorage.getItem('role') || sessionStorage.getItem('role');
-      window.logout = function(){
-        localStorage.removeItem('token');
-        localStorage.removeItem('role');
-        sessionStorage.removeItem('token');
-        sessionStorage.removeItem('role');
-        document.cookie = 'token=; Max-Age=0; path=/';
-        fetch('/logout',{method:'POST',headers:{'Authorization':token}});
-        window.location.href = 'index.php';
-      };
-      if(token){
-        if(reg) reg.style.display='none';
-        if(dash) dash.style.display='inline-flex';
-        if(logout) logout.style.display='inline-flex';
-        playLinks.forEach(a => a.href='dashboard.html');
-      }else{
-        playLinks.forEach(a => a.href='pub.php');
-      }
-      if(role === 'admin' && cfg){ cfg.style.display = 'inline-flex'; }
-    })();
-    (function(){
-      const nav = document.getElementById('nav');
-      const btn = document.getElementById('menuBtn');
-      if(!btn) return;
-      btn.addEventListener('click', () => {
-        const open = nav.classList.toggle('open');
-        btn.setAttribute('aria-expanded', String(open));
-      });
-    })();
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
-</body>
-</html>
+<?php
+// Legal notice page with optional in-game menu when SID is present.
+define('IN_ZDE', 1);
+if (isset($_GET['sid'])) {
+    $FILE_REQUIRES_PC = false;
+    include 'ingame.php';
+} else {
+    include 'gres.php';
+    include 'layout.php';
+}
+
+createlayout_top('ZeroDayEmpire - Legal');
+?>
+<h1>Legal</h1>
+<p>Dieses Projekt verwendet verschiedene Open​-Source​-Technologien:</p>
+<ul>
+  <li>PHP</li>
+  <li>Nginx</li>
+  <li>MariaDB</li>
+</ul>
+<p>Das Originalspiel inklusive Spielmechaniken basiert auf <a href="https://github.com/dergriewatz/htn-original">HackTheNet.org</a>.</p>
+<?php
+createlayout_bottom();
+?>

--- a/rules.php
+++ b/rules.php
@@ -1,8 +1,15 @@
 <?php
 define('IN_ZDE', 1);
 $starttime = microtime();
-include('gres.php');
-include('layout.php');
+// Load player data when a SID is supplied so the navigation reflects the
+// logged-in state. Without a SID the page is shown with the public layout.
+if (isset($_GET['sid'])) {
+    $FILE_REQUIRES_PC = false;
+    include 'ingame.php';
+} else {
+    include 'gres.php';
+    include 'layout.php';
+}
 
 function showdoc($fn, $te = '')
 {
@@ -37,3 +44,4 @@ createlayout_bottom();
 }
 
 showdoc('rules', 'Regeln');
+?>


### PR DESCRIPTION
## Summary
- Convert Impressum and Legal pages to use shared layout and load `ingame.php` when a SID is supplied so logged-in players keep their menu.
- Update Spielregeln page to conditionally include `ingame.php`, preserving the user menu for authenticated sessions.

## Testing
- `php -l impressum.php legal.php rules.php`


------
https://chatgpt.com/codex/tasks/task_b_68c5682e199c8325848052e0f41c1284