### PR TITLE
Remove card hover glow effect

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,8 +51,6 @@ a{color:inherit; text-decoration:none}
 /* Feature Cards */
 .features{ display:grid; gap:14px; grid-template-columns: repeat(12, 1fr); margin-top: 40px }
 .card{ grid-column: span 4; background: linear-gradient(180deg, rgba(255,255,255,.04), rgba(255,255,255,.02)); border: 1px solid var(--border); border-radius: var(--radius); padding: 18px; position:relative; overflow:hidden }
-.card::after{ content:""; position:absolute; inset:-2px; border-radius: inherit; background:none; filter: blur(16px); opacity:0; transition: .25s opacity; pointer-events:none }
-.card:hover::after{ opacity:.9 }
 .card h3{ margin:2px 0 6px; font-size: 18px }
 .card p{ margin:0; color:var(--muted) }
 .card .icon{ width: 36px; height: 36px; display:grid; place-items:center; border-radius:10px; background:rgba(var(--accent)/.12); border:1px solid rgba(var(--accent)/.35); margin-bottom:10px }


### PR DESCRIPTION
## Summary
- remove green hover light from card elements

## Testing
- `npx --yes stylelint style.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c5958625848325adfa28043092b1c5