### PR TITLE
Fix research processing to use correct PC field

### DIFF
--- a/includes/research.php
+++ b/includes/research.php
@@ -125,7 +125,8 @@ function research_process($now = null)
     if ($now === null) { $now = time(); }
     $r = db_query('SELECT * FROM research WHERE `end`<=\''.mysql_escape_string($now).'\' ORDER BY `start` ASC');
     while ($row = mysql_fetch_assoc($r)) {
-        db_query('INSERT INTO research_state SET pc=\''.mysql_escape_string($row['server']).'\', track=\''.mysql_escape_string($row['track']).'\', level=\''.mysql_escape_string($row['target_level']).'\' ON DUPLICATE KEY UPDATE level=VALUES(level)');
+        $pc = (int)$row['pc'];
+        db_query('INSERT INTO research_state SET pc=\''.mysql_escape_string($pc).'\', track=\''.mysql_escape_string($row['track']).'\', level=\''.mysql_escape_string($row['target_level']).'\' ON DUPLICATE KEY UPDATE level=VALUES(level)');
         db_query('DELETE FROM research WHERE id=\''.mysql_escape_string($row['id']).'\'');
     }
 }


### PR DESCRIPTION
## Summary
- Use the `pc` column from research entries when updating `research_state`
- Cast `pc` to integer before escaping to avoid invalid inserts

## Testing
- `php -l includes/research.php`


------
https://chatgpt.com/codex/tasks/task_b_68c7f8c069ec8325ab329563119ecdf8