### PR TITLE
Add foundational attacks system with SQL schema and UI skeleton

### DIFF
--- a/attacks.php
+++ b/attacks.php
@@ -1,0 +1,30 @@
+<?php
+// Basic attack menu page.
+define('IN_ZDE', 1);
+$FILE_REQUIRES_PC = true;
+require_once __DIR__.'/ingame.php';
+require_once __DIR__.'/includes/attacks_lib.php';
+
+$pc = $pcid; // from ingame.php
+$messages = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['start_code'])) {
+    $code = trim($_POST['start_code']);
+    $res = attacks_start_controller($pc, $code);
+    $messages[] = $res['message'];
+}
+
+$defs = attacks_list_all();
+$runs = attacks_recent_runs($pc, 20);
+
+createlayout_top('ZeroDayEmpire - Angriffe');
+
+echo '<header class="page-head"><h1>Angriffe</h1></header>';
+
+foreach ($messages as $m) {
+    echo '<p class="msg">'.htmlspecialchars($m).'</p>';
+}
+
+include __DIR__.'/templates/attacks_list.tpl.php';
+
+createlayout_bottom();

--- a/bin/attacks_finish.php
+++ b/bin/attacks_finish.php
@@ -1,0 +1,17 @@
+<?php
+// CLI helper to finish due attack runs. This is intentionally lightweight and
+// mainly demonstrates how the cronjob would call into the library.
+
+define('IN_ZDE', 1);
+require_once __DIR__.'/../includes/attacks_lib.php';
+
+// Placeholder: in a full implementation finish_due_runs() would check DB for
+// expired entries and payout coins. Here we just provide the function stub so
+// that the cron script can run without fatal errors.
+
+if (function_exists('finish_due_runs')) {
+    finish_due_runs();
+} else {
+    // simple stub
+    echo "finish_due_runs() not implemented\n";
+}

--- a/includes/attacks_lib.php
+++ b/includes/attacks_lib.php
@@ -1,0 +1,191 @@
+<?php
+// Basic library for attack actions. This is a lightweight implementation
+// that follows the specification in the task description. It is not a full
+// game ready system but provides reusable calculation helpers and basic
+// dependency checks so that the UI can be built around it.
+
+require_once __DIR__.'/attacks_queries.php';
+
+// ---------------------------------------------------------------------------
+// Constants used for balancing. These can be tweaked later without touching
+// the database content.
+// ---------------------------------------------------------------------------
+
+const ATTACK_MAX_LEVEL_DEFAULT = 5;
+const RISK_REDUCTION_PER_RAM = 0.01;   // 1%
+const DURATION_REDUCTION_PER_RAM = 0.01;
+const DURATION_REDUCTION_PER_CPU = 0.02;
+const DURATION_REDUCTION_PER_LAN = 0.01;
+const RISK_REDUCTION_PER_R_VEIL = 0.01;
+const PARALLEL_SLOTS_PER_LAN = 3; // 1 + floor(lan/3)
+
+// Mapping of external research/hardware keys used in the SQL seed data to
+// the real codes in the game. In this repository the codes already match, so
+// the mapping is mostly identity but keeping the structure allows future
+// adjustments with little effort.
+const RMAP = [
+  'r_se'   => 'r_se',
+  'r_veil' => 'r_veil',
+  'r_pers' => 'r_pers',
+  'r_c2'   => 'r_c2',
+  'r_data' => 'r_data',
+  'r_lab'  => 'r_lab',
+  'r_bauk' => 'r_bauk',
+  'r_rans' => 'r_rans',
+];
+const HMAP = [
+  'cpu' => 'cpu', 'ram' => 'ram', 'lan' => 'lan', 'mm' => 'mm', 'bb' => 'bb',
+  'sdk' => 'sdk', 'mk' => 'mk', 'trojan' => 'trojan',
+];
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Return definition of an attack action.
+ */
+function get_attack_def(string $code): ?array {
+    return db_fetch_attack_def($code);
+}
+
+/**
+ * Load the player's state for an attack. If none exists default level 1/xp 0
+ * is returned.
+ */
+function get_attack_state(int $pc, string $code): array {
+    $state = db_fetch_attack_state($pc, $code);
+    if (!$state) {
+        return ['level' => 1, 'xp' => 0];
+    }
+    return $state;
+}
+
+/**
+ * Calculate effective parameters for an action based on definition, state,
+ * inventory and research levels.
+ */
+function calc_effective_params(array $def, array $state, array $inventar, array $research): array {
+    $level = (int)($state['level'] ?? 1);
+    $cost = (int)round($def['base_cost'] * pow($def['cost_mult'], $level - 1));
+    $payout = (int)round($def['base_payout'] * pow($def['payout_mult'], $level - 1));
+    $duration = (float)($def['base_time_min'] * pow($def['time_mult'], $level - 1));
+    $risk = (float)($def['base_risk_pct'] * pow(0.90, $level - 1));
+
+    // hardware / research modifiers
+    $ram = (int)($inventar['ram'] ?? 0);
+    $cpu = (int)($inventar['cpu'] ?? 0);
+    $lan = (int)($inventar['lan'] ?? 0);
+    $rveil = (int)($research['r_veil'] ?? 0);
+
+    $risk -= $ram * RISK_REDUCTION_PER_RAM * 100;
+    $risk -= $rveil * RISK_REDUCTION_PER_R_VEIL * 100;
+    if ($risk < 0) $risk = 0;
+
+    $duration *= (1 - $ram * DURATION_REDUCTION_PER_RAM);
+    $duration *= (1 - $cpu * DURATION_REDUCTION_PER_CPU);
+    $duration *= (1 - $lan * DURATION_REDUCTION_PER_LAN);
+
+    $slots = 1 + floor($lan / PARALLEL_SLOTS_PER_LAN);
+
+    return [
+        'cost' => $cost,
+        'payout_expected' => $payout,
+        'duration_min' => (int)round($duration),
+        'risk_pct' => (int)round($risk),
+        'parallel_slots' => (int)$slots,
+    ];
+}
+
+/**
+ * Very small dependency check. The function returns an array with keys
+ * `ok` and `missing`. Missing contains human readable labels.
+ * This implementation does not query research/hardware and therefore only
+ * reports dependencies based on the arrays provided.
+ */
+function check_dependencies(int $pc, string $code, int $targetLevel): array {
+    $deps = db_fetch_deps($code);
+    $missing = [];
+    foreach ($deps as $dep) {
+        if ($dep['dep_type'] === 'unlock' && $targetLevel === 1) {
+            $ok = check_single_dep($pc, $dep);
+            if (!$ok) $missing[] = $dep['req_key'];
+        } elseif ($dep['dep_type'] === 'level_gate' && $targetLevel >= $dep['gate_level']) {
+            $ok = check_single_dep($pc, $dep);
+            if (!$ok) $missing[] = $dep['req_key'];
+        }
+    }
+    return ['ok' => empty($missing), 'missing' => $missing];
+}
+
+function check_single_dep(int $pc, array $dep): bool {
+    if ($dep['req_kind'] === 'research') {
+        $level = db_fetch_research_level($pc, $dep['req_key']);
+        return $level >= $dep['req_level'];
+    }
+    // hardware
+    $level = db_fetch_hardware_level($pc, $dep['req_key']);
+    return $level >= $dep['req_level'];
+}
+
+/**
+ * Determine how many runs are currently active for a given player.
+ */
+function count_running(int $pc): int {
+    return db_count_running($pc);
+}
+
+/**
+ * Calculate available parallel slots from LAN level.
+ */
+function current_parallel_slots(int $lan): int {
+    return 1 + floor($lan / PARALLEL_SLOTS_PER_LAN);
+}
+
+/**
+ * Simple cooldown checker using attack_runs table.
+ */
+function is_on_cooldown(int $pc, string $code): bool {
+    $ts = db_cooldown_until($pc, $code);
+    return $ts !== null && $ts > time();
+}
+
+/**
+ * Wrapper for starting a run. This only covers the basic DB insert and cost
+ * deduction. The heavy lifting like risk or payout calculation is omitted in
+ * this simplified reference implementation.
+ */
+function start_run(int $pc, string $code): int {
+    $def = get_attack_def($code);
+    if (!$def) { throw new Exception('Unknown attack'); }
+    $state = get_attack_state($pc, $code);
+    $inv = db_fetch_hardware_all($pc);
+    $research = db_fetch_research_all($pc);
+    $params = calc_effective_params($def, $state, $inv, $research);
+    return db_start_run($pc, $code, $state['level'], $params);
+}
+
+// ----------------------------------------------------------------------------
+// Controller helpers used by attacks.php
+// ----------------------------------------------------------------------------
+
+function attacks_start_controller(int $pc, string $code): array {
+    $deps = check_dependencies($pc, $code, get_attack_state($pc, $code)['level']);
+    if (!$deps['ok']) return ['ok'=>false,'message'=>'Voraussetzungen fehlen: '.implode(', ',$deps['missing'])];
+    $lan = db_fetch_hardware_level($pc, 'lan');
+    $slots = current_parallel_slots($lan);
+    if (count_running($pc) >= $slots) return ['ok'=>false,'message'=>'Alle Angriffsslots belegt.'];
+    if (is_on_cooldown($pc,$code)) return ['ok'=>false,'message'=>'Cooldown aktiv.'];
+    $runId = start_run($pc,$code);
+    return ['ok'=>true,'message'=>'Angriff gestartet (#'.$runId.').'];
+}
+
+// expose fetch helpers for UI use ------------------------------------------------
+function attacks_list_all(): array {
+    return db_list_attacks_with_state();
+}
+
+function attacks_recent_runs(int $pc, int $limit = 20): array {
+    return db_recent_runs($pc, $limit);
+}
+

--- a/includes/attacks_queries.php
+++ b/includes/attacks_queries.php
@@ -1,0 +1,113 @@
+<?php
+// This file contains thin wrappers around SQL queries used by the attacks
+// module. The real game would use a database abstraction layer; here we use
+// the legacy mysql_* style helpers already present in the project.
+
+if (!defined('IN_ZDE')) {
+    define('IN_ZDE', 1);
+}
+require_once __DIR__.'/../config.php';
+
+// Fetch a single attack definition
+function db_fetch_attack_def(string $code): ?array {
+    $code = mysql_escape_string($code);
+    $r = mysql_query("SELECT * FROM attack_actions WHERE code='".$code."'");
+    if ($r && $row = mysql_fetch_assoc($r)) {
+        return $row;
+    }
+    return null;
+}
+
+// Fetch player state for an attack
+function db_fetch_attack_state(int $pc, string $code): ?array {
+    $code = mysql_escape_string($code);
+    $pc = (int)$pc;
+    $r = mysql_query("SELECT level,xp FROM attack_state WHERE pc=$pc AND code='".$code."'");
+    if ($r && $row = mysql_fetch_assoc($r)) { return $row; }
+    return null;
+}
+
+// Fetch all deps for an attack
+function db_fetch_deps(string $code): array {
+    $code = mysql_escape_string($code);
+    $res = mysql_query("SELECT * FROM attack_deps WHERE code='".$code."'");
+    $rows = [];
+    while ($res && $row = mysql_fetch_assoc($res)) { $rows[] = $row; }
+    return $rows;
+}
+
+// Simple hardware / research level queries (legacy tables assumed)
+function db_fetch_research_level(int $pc, string $key): int {
+    $pc = (int)$pc; $key = mysql_escape_string($key);
+    $r = mysql_query("SELECT level FROM research_tracks WHERE pc=$pc AND track='".$key."'");
+    if ($r && $row = mysql_fetch_assoc($r)) return (int)$row['level'];
+    return 0;
+}
+
+function db_fetch_hardware_level(int $pc, string $key): int {
+    $pc = (int)$pc; $key = mysql_escape_string($key);
+    $r = mysql_query("SELECT qty FROM hardware WHERE pc=$pc AND code='".$key."'");
+    if ($r && $row = mysql_fetch_assoc($r)) return (int)$row['qty'];
+    return 0;
+}
+
+function db_fetch_hardware_all(int $pc): array {
+    $pc = (int)$pc;
+    $r = mysql_query("SELECT code,qty FROM hardware WHERE pc=$pc");
+    $rows = [];
+    while ($r && $row = mysql_fetch_assoc($r)) { $rows[$row['code']] = (int)$row['qty']; }
+    return $rows;
+}
+
+function db_fetch_research_all(int $pc): array {
+    $pc = (int)$pc;
+    $r = mysql_query("SELECT track,level FROM research_tracks WHERE pc=$pc");
+    $rows = [];
+    while ($r && $row = mysql_fetch_assoc($r)) { $rows[$row['track']] = (int)$row['level']; }
+    return $rows;
+}
+
+function db_count_running(int $pc): int {
+    $pc = (int)$pc;
+    $r = mysql_query("SELECT COUNT(*) AS c FROM attack_runs WHERE pc=$pc AND status='running'");
+    if ($r && $row = mysql_fetch_assoc($r)) return (int)$row['c'];
+    return 0;
+}
+
+function db_cooldown_until(int $pc, string $code): ?int {
+    $pc = (int)$pc; $code = mysql_escape_string($code);
+    $r = mysql_query("SELECT MAX(cooldown_until) AS c FROM attack_runs WHERE pc=$pc AND code='".$code."'");
+    if ($r && $row = mysql_fetch_assoc($r) && $row['c']) return strtotime($row['c']);
+    return null;
+}
+
+// Start a run: deduct cost and insert log entry
+function db_start_run(int $pc, string $code, int $level, array $params): int {
+    $pc = (int)$pc; $code = mysql_escape_string($code);
+    $cost = (int)$params['cost'];
+    $payout = (int)$params['payout_expected'];
+    $dur = (int)$params['duration_min'];
+    $start = time();
+    $end = $start + $dur * 60;
+    // cost deduction (legacy table cc field on pcs?)
+    mysql_query("UPDATE pcs SET cc=cc-$cost WHERE id=$pc");
+    mysql_query("INSERT INTO attack_runs(pc,code,level_snapshot,cost,payout_expected,status,started_at,ends_at) VALUES ($pc,'$code',$level,$cost,$payout,'running',FROM_UNIXTIME($start),FROM_UNIXTIME($end))");
+    return mysql_insert_id();
+}
+
+// fetch list of attack defs joined with player state - placeholder simple query
+function db_list_attacks_with_state(): array {
+    $res = mysql_query("SELECT * FROM attack_actions");
+    $rows = [];
+    while ($res && $row = mysql_fetch_assoc($res)) { $rows[] = $row; }
+    return $rows;
+}
+
+function db_recent_runs(int $pc, int $limit): array {
+    $pc = (int)$pc; $limit = (int)$limit;
+    $res = mysql_query("SELECT * FROM attack_runs WHERE pc=$pc ORDER BY id DESC LIMIT $limit");
+    $rows = [];
+    while ($res && $row = mysql_fetch_assoc($res)) { $rows[] = $row; }
+    return $rows;
+}
+

--- a/layout.php
+++ b/layout.php
@@ -72,6 +72,7 @@ function createlayout_top($title = 'ZeroDayEmpire', $nomenu = false)
             echo '<a href="battle.php?m=opc&sid=' . $usr['sid'] . '">Operation Center</a>';
             echo '<a href="upgradelist.php?sid=' . $usr['sid'] . '">Upgrade</a>';
             echo '<a href="research.php?sid=' . $usr['sid'] . '">Forschung</a>';
+            echo '<a href="attacks.php?sid=' . $usr['sid'] . '">Angriffe</a>';
             echo '<a href="ranking.php?m=ranking' . $sid . '">Rangliste</a>';
             echo '<a href="user.php?a=config' . $sid . '">Optionen</a>';
             echo '<a href="login.php?a=logout' . $sid . '">Abmelden</a>';

--- a/sql/2024-06-07_attacks.sql
+++ b/sql/2024-06-07_attacks.sql
@@ -1,0 +1,163 @@
+-- Migration for attacks tables and seed data
+
+-- Stammdaten aller Angriffsaktionen
+CREATE TABLE IF NOT EXISTS attack_actions (
+  code            VARCHAR(32)  PRIMARY KEY,
+  name            VARCHAR(120) NOT NULL,
+  descr           VARCHAR(512) NOT NULL,
+  base_cost       INT NOT NULL,
+  base_payout     INT NOT NULL,
+  base_time_min   INT NOT NULL,
+  base_risk_pct   TINYINT NOT NULL,
+  cost_mult       DECIMAL(6,3) NOT NULL DEFAULT 1.600,
+  payout_mult     DECIMAL(6,3) NOT NULL DEFAULT 1.700,
+  time_mult       DECIMAL(6,3) NOT NULL DEFAULT 1.250,
+  max_level       TINYINT NOT NULL DEFAULT 5,
+  tick_minutes    INT NOT NULL DEFAULT 0,
+  cooldown_min    INT NOT NULL DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Spieler-/PC-spezifischer Fortschritt je Aktion
+CREATE TABLE IF NOT EXISTS attack_state (
+  pc              INT NOT NULL,
+  code            VARCHAR(32) NOT NULL,
+  level           TINYINT NOT NULL DEFAULT 1,
+  xp              INT NOT NULL DEFAULT 0,
+  PRIMARY KEY(pc, code),
+  CONSTRAINT fk_attack_state_action FOREIGN KEY (code) REFERENCES attack_actions(code)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Lauf-Log einzelner Ausführungen
+CREATE TABLE IF NOT EXISTS attack_runs (
+  id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+  pc              INT NOT NULL,
+  code            VARCHAR(32) NOT NULL,
+  level_snapshot  TINYINT NOT NULL,
+  cost            INT NOT NULL,
+  payout_expected INT NOT NULL,
+  payout_final    INT DEFAULT NULL,
+  risk_roll       DECIMAL(6,3) DEFAULT NULL,
+  status          ENUM('running','success','fail','cancelled') NOT NULL,
+  started_at      DATETIME NOT NULL,
+  ends_at         DATETIME NOT NULL,
+  finished_at     DATETIME DEFAULT NULL,
+  cooldown_until  DATETIME DEFAULT NULL,
+  notes           VARCHAR(512) DEFAULT NULL,
+  INDEX ix_pc_status (pc, status),
+  INDEX ix_pc_code (pc, code),
+  CONSTRAINT fk_attack_runs_action FOREIGN KEY (code) REFERENCES attack_actions(code)
+    ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Abhängigkeiten: Unlocks und Level-Gates
+CREATE TABLE IF NOT EXISTS attack_deps (
+  code        VARCHAR(32) NOT NULL,
+  dep_type    ENUM('unlock','level_gate') NOT NULL,
+  gate_level  TINYINT NOT NULL DEFAULT 1,
+  req_kind    ENUM('research','hardware') NOT NULL,
+  req_key     VARCHAR(32) NOT NULL,
+  req_level   INT NOT NULL DEFAULT 1,
+  PRIMARY KEY (code, dep_type, gate_level, req_kind, req_key),
+  CONSTRAINT fk_attack_deps_action FOREIGN KEY (code) REFERENCES attack_actions(code)
+    ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Seed data for attack_actions
+REPLACE INTO attack_actions
+(code, name, descr, base_cost, base_payout, base_time_min, base_risk_pct, cost_mult, payout_mult, time_mult, max_level, tick_minutes, cooldown_min)
+VALUES
+('a_phish',   'Phishing-Kampagne (E-Mail)', 'Einstieg in Social Engineering: Massenmail mit steigender Conversion.', 10,  50,  3, 12, 1.60, 1.70, 1.25, 5, 0, 0),
+('a_combo',   'Credential-Stuffing',        'Automatisiertes Testen geleakter Logins, Trefferquote steigt mit Level.', 15,  45,  4, 14, 1.60, 1.70, 1.25, 5, 0, 0),
+('a_adfraud', 'Ad-Fraud/Traffic',           'Traffic monetarisieren, skaliert über MoneyMarket.',                    20,  60,  5, 10, 1.60, 1.70, 1.25, 5, 0, 0),
+('a_lpage',   'Phish-Kit & Landing-Page',   'Glaubwürdige Fake-Sites erhöhen Konversion.',                           30, 120,  8, 15, 1.60, 1.70, 1.25, 5, 0, 0),
+('a_keylog',  'Keylogger-Dropper',          'Persistente Kleingeld-Abflüsse; liefert Tick-Ertrag.',                  40, 150, 12, 18, 1.60, 1.70, 1.25, 5, 30, 0),
+('a_miner',   'Cryptojacking-Deployment',   'CPU-gebundene Mining-Erträge über Zeit.',                               60, 220, 15, 20, 1.60, 1.70, 1.25, 5, 60, 0),
+('a_data',    'Datenhehlerei',              'Abfluss und Verkauf von Datensätzen mit hoher Varianz.',                80, 260, 18, 22, 1.60, 1.70, 1.25, 5, 0, 0),
+('a_botrent', 'Botnet-Vermietung',          'Leistung vermieten; stark skalierend mit Netzwerk.',                    120,420, 25, 25, 1.60, 1.70, 1.25, 5, 0, 0),
+('a_rans',    'Ransomware-Kampagne',        'Hoher Ertrag, hohes Risiko, anschließender Cooldown.',                 200,900, 35, 28, 1.60, 1.70, 1.25, 5, 0, 30),
+('a_0day',    '0-Day-Entwicklung & Broker', 'Lange Laufzeit, mittleres Risiko, einmalige große Auszahlung.',        250,1000, 45, 18, 1.60, 1.70, 1.25, 5, 0, 0);
+
+-- Dependencies
+-- a_phish
+REPLACE INTO attack_deps VALUES
+('a_phish','unlock',1,'research','r_se',1),
+('a_phish','unlock',1,'hardware','lan',1),
+('a_phish','level_gate',3,'research','r_se',2),
+('a_phish','level_gate',4,'research','r_veil',2),
+('a_phish','level_gate',5,'research','r_c2',2);
+
+-- a_combo
+REPLACE INTO attack_deps VALUES
+('a_combo','unlock',1,'research','r_ana',1),
+('a_combo','unlock',1,'hardware','sdk',1),
+('a_combo','unlock',1,'hardware','lan',2),
+('a_combo','level_gate',3,'research','r_lab',2),
+('a_combo','level_gate',4,'research','r_bauk',3),
+('a_combo','level_gate',5,'research','r_veil',3);
+
+-- a_adfraud
+REPLACE INTO attack_deps VALUES
+('a_adfraud','unlock',1,'hardware','mm',1),
+('a_adfraud','unlock',1,'hardware','cpu',1),
+('a_adfraud','level_gate',3,'hardware','mm',3),
+('a_adfraud','level_gate',4,'hardware','mm',5),
+('a_adfraud','level_gate',5,'hardware','mm',8),
+('a_adfraud','level_gate',4,'research','r_veil',2);
+
+-- a_lpage
+REPLACE INTO attack_deps VALUES
+('a_lpage','unlock',1,'hardware','mk',2),
+('a_lpage','unlock',1,'research','r_bauk',2),
+('a_lpage','unlock',1,'research','r_se',2),
+('a_lpage','level_gate',4,'research','r_veil',3),
+('a_lpage','level_gate',5,'research','r_c2',3);
+
+-- a_keylog
+REPLACE INTO attack_deps VALUES
+('a_keylog','unlock',1,'hardware','mk',4),
+('a_keylog','unlock',1,'hardware','trojan',2),
+('a_keylog','unlock',1,'research','r_pers',2),
+('a_keylog','level_gate',3,'research','r_veil',2),
+('a_keylog','level_gate',4,'research','r_data',2),
+('a_keylog','level_gate',5,'research','r_pers',3);
+
+-- a_miner
+REPLACE INTO attack_deps VALUES
+('a_miner','unlock',1,'hardware','mk',5),
+('a_miner','unlock',1,'hardware','trojan',3),
+('a_miner','unlock',1,'research','r_pers',3),
+('a_miner','level_gate',4,'research','r_c2',3),
+('a_miner','level_gate',5,'research','r_veil',4);
+
+-- a_data
+REPLACE INTO attack_deps VALUES
+('a_data','unlock',1,'research','r_data',3),
+('a_data','unlock',1,'hardware','mk',3),
+('a_data','level_gate',4,'research','r_lab',3),
+('a_data','level_gate',5,'research','r_veil',4);
+
+-- a_botrent
+REPLACE INTO attack_deps VALUES
+('a_botrent','unlock',1,'research','r_c2',3),
+('a_botrent','unlock',1,'hardware','lan',4),
+('a_botrent','level_gate',4,'research','r_pers',3),
+('a_botrent','level_gate',5,'research','r_veil',4);
+
+-- a_rans
+REPLACE INTO attack_deps VALUES
+('a_rans','unlock',1,'research','r_rans',3),
+('a_rans','unlock',1,'hardware','trojan',4),
+('a_rans','unlock',1,'hardware','mk',6),
+('a_rans','level_gate',4,'research','r_pers',4),
+('a_rans','level_gate',5,'research','r_c2',4),
+('a_rans','level_gate',5,'research','r_data',4),
+('a_rans','level_gate',5,'research','r_veil',4);
+
+-- a_0day
+REPLACE INTO attack_deps VALUES
+('a_0day','unlock',1,'research','r_lab',4),
+('a_0day','unlock',1,'research','r_bauk',4),
+('a_0day','level_gate',5,'research','r_veil',4),
+('a_0day','level_gate',5,'research','r_c2',4);
+

--- a/templates/attacks_list.tpl.php
+++ b/templates/attacks_list.tpl.php
@@ -1,0 +1,18 @@
+<?php
+// Simple template rendering attack definitions.
+?>
+<section class="attacks-grid">
+  <?php foreach ($defs as $d): ?>
+    <article class="card attack">
+      <header>
+        <h3><?php echo htmlspecialchars($d['name']); ?></h3>
+        <span class="badge level">Lv.1</span>
+      </header>
+      <p class="descr"><?php echo htmlspecialchars($d['descr']); ?></p>
+      <form method="post">
+        <input type="hidden" name="start_code" value="<?php echo htmlspecialchars($d['code']); ?>">
+        <button class="btn">Starten</button>
+      </form>
+    </article>
+  <?php endforeach; ?>
+</section>


### PR DESCRIPTION
## Summary
- introduce migration for attack actions, state, runs and dependencies
- add PHP helpers and database query wrappers for basic attack handling
- provide initial attacks page, template and cron stub
- link new attacks menu entry in main navigation

## Testing
- `php -l includes/attacks_lib.php`
- `php -l includes/attacks_queries.php`
- `php -l attacks.php`
- `php -l templates/attacks_list.tpl.php`
- `php -l bin/attacks_finish.php`


------
https://chatgpt.com/codex/tasks/task_b_68c8083271b08325b8da42b598e9ee20